### PR TITLE
refactor(village): refactor error message to use reusable lang

### DIFF
--- a/src/lang/locales/en.json
+++ b/src/lang/locales/en.json
@@ -7,5 +7,6 @@
 	"validation.email": "validation.email",
 	"auth.user.failed": "user not found!",
 	"auth.password.failed": "password not match out record!",
-	"validation.exists": "validation.exists"
+	"validation.exists": "validation.exists",
+	"error.exists": "{{ entity }} with id {{ id }} does not exist"
 }

--- a/src/modules/villages/village_service.ts
+++ b/src/modules/villages/village_service.ts
@@ -1,6 +1,7 @@
 import httpStatus from 'http-status'
 import redis from '../../config/redis'
 import { HttpError } from '../../handler/exception'
+import lang from '../../lang'
 import { Village as Entity } from './village_entity'
 import { Village as Repository } from './village_repository'
 
@@ -57,7 +58,7 @@ export namespace Village {
     const item: any = await Repository.findById(id)
 
     if (!item) {
-      throw new HttpError(httpStatus.NOT_FOUND, `village with id ${id} does not exits`)
+      throw new HttpError(httpStatus.NOT_FOUND, lang.__('error.exists', { entity: 'Village', id }))
     }
 
     const result: Entity.ResponseFindById = {


### PR DESCRIPTION
# Overview
## Background
- We want to avoid hardcoded error message

## Changes
- Move the error message to external json file and make it reusable

cc @jabardigitalservice/jds-backend 

## Evidence
- title: refactor village not found error message to use reusable lang
- project: Desa Digital
- participants:  @ayocodingit @firmanJS @tukangremot @rachadiannovansyah