### PR TITLE
feat(redis): configure redis cache invalidation for testing

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,29 +2,30 @@ import type { Config } from '@jest/types'
 
 export default async (): Promise<Config.InitialOptions> => {
   return {
-    forceExit: true,
     bail: 1,
-    verbose: true,
     clearMocks: true,
-    testEnvironment: 'node',
-    transform: {
-      '^.+\\.ts?$': 'ts-jest'
-    },
-    setupFilesAfterEnv: ['jest-extended'],
-    globals: {
-      'ts-jest': {
-        diagnostics: false
-      }
-    },
-    testMatch: [
-      '**/*_test.ts'
-    ],
     collectCoverage: true,
     collectCoverageFrom: [
+      './src/helpers/test/*.ts',
       './src/modules/**/*.ts',
-      './src/helpers/test/*.ts'
     ],
     coverageReporters: ['lcov'],
-    detectOpenHandles: true
-  }
+    detectOpenHandles: true,
+    forceExit: true,
+    globals: {
+      'ts-jest': {
+        diagnostics: false,
+      },
+    },
+    testEnvironment: 'node',
+    testMatch: ['**/*_test.ts'],
+    transform: {
+      '^.+\\.ts?$': 'ts-jest',
+    },
+    setupFilesAfterEnv: [
+      'jest-extended',
+      './src/config/jest.ts'
+    ],
+    verbose: true,
+  };
 }

--- a/src/config/jest.ts
+++ b/src/config/jest.ts
@@ -4,6 +4,6 @@ global.beforeEach(async () => {
   await redis.flushall();
 });
 
-global.afterAll(() => {
-  redis.flushall();
+global.afterAll(async () => {
+  await redis.flushall();
 })

--- a/src/config/jest.ts
+++ b/src/config/jest.ts
@@ -1,7 +1,7 @@
 import redis from '../config/redis';
 
-global.beforeEach(() => {
-  redis.flushall();
+global.beforeEach(async () => {
+  await redis.flushall();
 });
 
 global.afterAll(() => {

--- a/src/config/jest.ts
+++ b/src/config/jest.ts
@@ -1,0 +1,9 @@
+import redis from '../config/redis';
+
+global.beforeEach(() => {
+  redis.flushall();
+});
+
+global.afterAll(() => {
+  redis.flushall();
+})

--- a/src/config/jest.ts
+++ b/src/config/jest.ts
@@ -1,9 +1,9 @@
 import redis from '../config/redis';
 
 global.beforeEach(async () => {
-  await redis.flushall();
+  await redis.flushall()
 });
 
 global.afterAll(async () => {
-  await redis.flushall();
+  await redis.flushall()
 })

--- a/src/config/redis.ts
+++ b/src/config/redis.ts
@@ -15,5 +15,6 @@ export default {
   get: promisify(client.get).bind(client),
   set: promisify(client.set).bind(client),
   del: promisify(client.del).bind(client),
-  default: client
+  flushall: promisify(client.flushall).bind(client),
+  default: client,
 }

--- a/src/modules/villages/village_test.ts
+++ b/src/modules/villages/village_test.ts
@@ -1,5 +1,4 @@
 import request from 'supertest'
-import redis from '../../config/redis'
 import app from '../../server'
 import { Village as Repository } from './village_repository'
 import KnexPostgis from 'knex-postgis'
@@ -22,7 +21,6 @@ describe('seed data', () => {
 
 describe('tests villages', () => {
   it('test success findAll with location ', async () => {
-    await redis.del('find_all_with_location')
     return request(app)
       .get('/v1/villages/list-with-location')
       .expect(200)
@@ -52,7 +50,6 @@ describe('tests villages', () => {
 
 describe('tests villages', () => {
   it('test success findAll with location filter', async () => {
-    await redis.del('find_all_with_location')
     return request(app)
       .get('/v1/villages/list-with-location')
       .query({ name: 'test', level: 1 })


### PR DESCRIPTION
# Overview
## Background
- Current test setup does not invalidate the cache before test. Therefore, we need to invalidate the cache that will be involved in the test manually.
- After running the test, the cache is still there and needs manual invalidation, otherwise, it will also be used in the dev environment.

## Changes Proposed
- Use a global beforeEach with jest, so we can flush our cache database right before each test.
  - This way, we don't need to bother and invalidate the needed cache value for all our tests.
  - The time it takes is also not very long, the docs https://redis.io/commands/FLUSHALL says that it runs in O(n) time complexity. Since we only use 1 or 2 caches for each test, it will add just 1 or 2 extra operations for each test, then.
- It also guarantees that between the dev and test environment, the cache will not be mixed up.

## Further Change Recommendation
- We can use the global beforeEach to truncate our database, so each test will be atomic.
  - This is related to our database in test environment, which as of now, is being used across different tests. In the future, when we got hundreds or thousands of tests, this will be terribly painful.
  - But this topic can be discussed furthermore.

cc @jabardigitalservice/jds-backend 

## Evidence
- Title: configure redis cache invalidation for testing
- Project: Desa Digital
- Participants:  @ayocodingit @firmanJS @sandisunandar99 @tukangremot