### PR TITLE
sprint 2 - add where by name village case sensitive

### DIFF
--- a/src/modules/villages/village_repository.ts
+++ b/src/modules/villages/village_repository.ts
@@ -22,7 +22,7 @@ export namespace Village {
       .where('villages.is_active', true)
       .orderBy('villages.name', 'asc')
 
-    if (requestQuery.name) query.where('villages.name', requestQuery.name)
+    if (requestQuery.name) query.where('villages.name', 'LIKE', `%${requestQuery.name}%`)
     if (requestQuery.level) query.where('villages.level', requestQuery.level)
 
     return query


### PR DESCRIPTION
# overview

- add where by name village case sensitive for needed search by keypress

related task:
![image](https://user-images.githubusercontent.com/41193120/140006017-3a7a40c5-e751-4ea3-9166-ad9f0190076d.png)


cc: @jabardigitalservice/jds-backend 

# evidence 
- title: add where by name village case sensitive
- project: Desa Digital
- participants: @ayocodingit @sandisunandar99 @tukangremot @rindibudiaramdhan @indraprasetya154 @setiadijoe 