### PR TITLE
sprint-2/query partners using cursor query

### DIFF
--- a/src/config/jest.ts
+++ b/src/config/jest.ts
@@ -2,12 +2,12 @@ import redis from '../config/redis';
 
 global.beforeEach(() => {
   redis.flushall()
-});
+})
 
 global.afterAll(async () => {
   redis.flushall()
 
   await new Promise<void>(resolve => {
     redis.quit(() => resolve())
-  });
+  })
 })

--- a/src/database/migrations/20211008032602_create_table_partners.ts
+++ b/src/database/migrations/20211008032602_create_table_partners.ts
@@ -12,7 +12,7 @@ export async function up (knex: Knex): Promise<void> {
         table.string('logo')
         table.integer('total_village')
         table.string('website')
-        table.timestamp('created_at').notNullable()
+        table.timestamp('created_at').notNullable().index()
         table.timestamp('updated_at')
       })
     }

--- a/src/modules/partners/partner_entity.ts
+++ b/src/modules/partners/partner_entity.ts
@@ -44,6 +44,7 @@ export namespace Partner {
     data: Struct[]
     meta: {
       next_page: string
+      per_page: number
     }
   }
 

--- a/src/modules/partners/partner_entity.ts
+++ b/src/modules/partners/partner_entity.ts
@@ -27,7 +27,7 @@ export namespace Partner {
     per_page?: string
   }
 
-  export interface QueryUsingCursorRepositoryParameters {
+  export interface QueryUsingCursor {
     name: string
     dateBefore: Date
     perPage: number

--- a/src/modules/partners/partner_entity.ts
+++ b/src/modules/partners/partner_entity.ts
@@ -47,6 +47,7 @@ export namespace Partner {
     meta: {
       next_page: string
       per_page: number
+      last_update?: Date
     }
   }
 

--- a/src/modules/partners/partner_entity.ts
+++ b/src/modules/partners/partner_entity.ts
@@ -22,8 +22,13 @@ export namespace Partner {
   }
 
   export interface RequestQueryUsingCursor extends Query {
-    date_before?: string
-    count?: string
+    next_page?: string
+    per_page?: string
+  }
+
+  export interface QueryUsingCursorRepositoryParameters {
+    dateBefore: Date
+    perPage: number
   }
 
   interface Meta extends metaPaginate {
@@ -33,6 +38,13 @@ export namespace Partner {
   export interface ResponseFindAll {
     data: Struct[]
     meta: Meta
+  }
+
+  export interface ResponseFindAllUsingCursor {
+    data: Struct[]
+    meta: {
+      next_page: string
+    }
   }
 
   export interface RequestQuerySuggestion extends Query {

--- a/src/modules/partners/partner_entity.ts
+++ b/src/modules/partners/partner_entity.ts
@@ -21,6 +21,11 @@ export namespace Partner {
     current_page: string
   }
 
+  export interface RequestQueryUsingCursor extends Query {
+    date_before?: string
+    count?: string
+  }
+
   interface Meta extends metaPaginate {
     last_update?: Date
   }

--- a/src/modules/partners/partner_entity.ts
+++ b/src/modules/partners/partner_entity.ts
@@ -22,11 +22,13 @@ export namespace Partner {
   }
 
   export interface RequestQueryUsingCursor extends Query {
+    name?: string
     next_page?: string
     per_page?: string
   }
 
   export interface QueryUsingCursorRepositoryParameters {
+    name: string
     dateBefore: Date
     perPage: number
   }

--- a/src/modules/partners/partner_entity.ts
+++ b/src/modules/partners/partner_entity.ts
@@ -1,5 +1,5 @@
-import { metaPaginate } from '../../helpers/paginate';
-import { Query } from '../../helpers/types';
+import { metaPaginate } from '../../helpers/paginate'
+import { Query } from '../../helpers/types'
 
 export namespace Partner {
   export interface Struct {

--- a/src/modules/partners/partner_handler.ts
+++ b/src/modules/partners/partner_handler.ts
@@ -19,9 +19,9 @@ router.get(
   })
 
 router.get(
-  '/v1/partnersByCursor',
+  '/v1/partnersUsingCursor',
   async (req: Request<never, never, never, Entity.RequestQueryUsingCursor>, res: Response, next: NextFunction) => {
-    const result: any = await Service.findAllUsingCursor(req.query);
+    const result: any = await Service.findAllUsingCursor(req.query)
 
     res.status(httpStatus.OK).json(result)
   }

--- a/src/modules/partners/partner_handler.ts
+++ b/src/modules/partners/partner_handler.ts
@@ -21,7 +21,7 @@ router.get(
 router.get(
   '/v1/partnersUsingCursor',
   async (req: Request<never, never, never, Entity.RequestQueryUsingCursor>, res: Response, next: NextFunction) => {
-    const result: any = await Service.findAllUsingCursor(req.query)
+    const result: Entity.ResponseFindAllUsingCursor = await Service.findAllUsingCursor(req.query)
 
     res.status(httpStatus.OK).json(result)
   }

--- a/src/modules/partners/partner_handler.ts
+++ b/src/modules/partners/partner_handler.ts
@@ -19,6 +19,15 @@ router.get(
   })
 
 router.get(
+  '/v1/partnersByCursor',
+  async (req: Request<never, never, never, Entity.RequestQueryUsingCursor>, res: Response, next: NextFunction) => {
+    const result: any = await Service.findAllUsingCursor(req.query);
+
+    res.status(httpStatus.OK).json(result)
+  }
+)
+
+router.get(
   '/v1/partners/suggestion',
   async (
     req: Request<never, never, never, Entity.RequestQuerySuggestion>,

--- a/src/modules/partners/partner_repository.ts
+++ b/src/modules/partners/partner_repository.ts
@@ -26,13 +26,15 @@ export namespace Partner {
     return query
   }
 
-  export const findAllUsingCursor = ({ dateBefore, perPage }: Entity.QueryUsingCursorRepositoryParameters) => {
+  export const findAllUsingCursor = ({ name, dateBefore, perPage }: Entity.QueryUsingCursorRepositoryParameters) => {
     const query = Partners()
       .select('id', 'name', 'total_village', 'logo', 'created_at', 'website')
       .whereNull('deleted_at')
       .where('created_at', '<', dateBefore)
       .orderBy('created_at', 'desc')
       .limit(perPage)
+
+    if (name) query.where('name', name);
 
     return query
   }

--- a/src/modules/partners/partner_repository.ts
+++ b/src/modules/partners/partner_repository.ts
@@ -26,13 +26,13 @@ export namespace Partner {
     return query
   }
 
-  export const findAllUsingCursor = (requestQuery: Entity.QueryUsingCursorRepositoryParameters) => {
+  export const findAllUsingCursor = (requestQuery: Entity.QueryUsingCursor) => {
     const query = Partners()
       .select('id', 'name', 'total_village', 'logo', 'created_at', 'website')
       .whereNull('deleted_at')
       .where('created_at', '<', requestQuery.dateBefore)
       .orderBy('created_at', 'desc')
-      .limit(requestQuery.perPage);
+      .limit(requestQuery.perPage)
 
     if (requestQuery.name) query.where('name', requestQuery.name);
 

--- a/src/modules/partners/partner_repository.ts
+++ b/src/modules/partners/partner_repository.ts
@@ -26,13 +26,13 @@ export namespace Partner {
     return query
   }
 
-  export const findAllUsingCursor = (dateBefore: Date, count: number) => {
+  export const findAllUsingCursor = ({ dateBefore, perPage }: Entity.QueryUsingCursorRepositoryParameters) => {
     const query = Partners()
       .select('id', 'name', 'total_village', 'logo', 'created_at', 'website')
       .whereNull('deleted_at')
-      .andWhere('created_at', '<', dateBefore)
+      .where('created_at', '<', dateBefore)
       .orderBy('created_at', 'desc')
-      .limit(count)
+      .limit(perPage)
 
     return query
   }

--- a/src/modules/partners/partner_repository.ts
+++ b/src/modules/partners/partner_repository.ts
@@ -26,15 +26,15 @@ export namespace Partner {
     return query
   }
 
-  export const findAllUsingCursor = ({ name, dateBefore, perPage }: Entity.QueryUsingCursorRepositoryParameters) => {
+  export const findAllUsingCursor = (requestQuery: Entity.QueryUsingCursorRepositoryParameters) => {
     const query = Partners()
       .select('id', 'name', 'total_village', 'logo', 'created_at', 'website')
       .whereNull('deleted_at')
-      .where('created_at', '<', dateBefore)
+      .where('created_at', '<', requestQuery.dateBefore)
       .orderBy('created_at', 'desc')
-      .limit(perPage)
+      .limit(requestQuery.perPage);
 
-    if (name) query.where('name', name);
+    if (requestQuery.name) query.where('name', requestQuery.name);
 
     return query
   }

--- a/src/modules/partners/partner_repository.ts
+++ b/src/modules/partners/partner_repository.ts
@@ -1,6 +1,6 @@
-import database from '../../config/database';
+import database from '../../config/database'
 import { perPage } from '../../helpers/paginate'
-import { Partner as Entity } from './partner_entity';
+import { Partner as Entity } from './partner_entity'
 
 export namespace Partner {
   export const Partners = () => database<Entity.Struct>('partners')
@@ -34,7 +34,7 @@ export namespace Partner {
       .orderBy('created_at', 'desc')
       .limit(requestQuery.perPage)
 
-    if (requestQuery.name) query.where('name', requestQuery.name);
+    if (requestQuery.name) query.where('name', requestQuery.name)
 
     return query
   }

--- a/src/modules/partners/partner_repository.ts
+++ b/src/modules/partners/partner_repository.ts
@@ -26,6 +26,17 @@ export namespace Partner {
     return query
   }
 
+  export const findAllUsingCursor = (dateBefore: Date, count: number) => {
+    const query = Partners()
+      .select('id', 'name', 'total_village', 'logo', 'created_at', 'website')
+      .whereNull('deleted_at')
+      .andWhere('created_at', '<', dateBefore)
+      .orderBy('created_at', 'desc')
+      .limit(count)
+
+    return query
+  }
+
   export const search = (requestQuery: Entity.RequestQuerySuggestion) => {
     const query = Partners()
       .select('id', 'name')

--- a/src/modules/partners/partner_rules.ts
+++ b/src/modules/partners/partner_rules.ts
@@ -1,4 +1,4 @@
-import Joi from 'joi';
+import Joi from 'joi'
 
 export namespace Partner {
   export const findAll = Joi.object({

--- a/src/modules/partners/partner_service.ts
+++ b/src/modules/partners/partner_service.ts
@@ -28,6 +28,8 @@ export namespace Partner {
     const dateBefore = requestQuery?.next_page ? new Date(requestQuery.next_page) : new Date()
     const perPage = Number(requestQuery?.per_page) || 6
 
+    const lastUpdate = await Repository.getLastUpdate()
+
     const items: any = await Repository.findAllUsingCursor({
       name,
       dateBefore,
@@ -39,6 +41,7 @@ export namespace Partner {
       meta: {
         next_page: items.length ? items[items.length - 1].created_at : null,
         per_page: items.length || 0,
+        last_update: lastUpdate?.created_at || null,
       }
     }
 

--- a/src/modules/partners/partner_service.ts
+++ b/src/modules/partners/partner_service.ts
@@ -23,16 +23,16 @@ export namespace Partner {
     return result
   }
 
-  export const findAllUsingCursor = async (requestQuery: Entity.RequestQueryUsingCursor): Promise<any> => {
-    const dateBefore = requestQuery?.date_before ? new Date(requestQuery.date_before) : new Date()
-    const count = +requestQuery?.count || 6
+  export const findAllUsingCursor = async (requestQuery: Entity.RequestQueryUsingCursor): Promise<Entity.ResponseFindAllUsingCursor> => {
+    const dateBefore = requestQuery?.next_page ? new Date(requestQuery.next_page) : new Date()
+    const perPage = Number(requestQuery?.per_page) || 6
 
-    const items: any = await Repository.findAllUsingCursor(
+    const items: any = await Repository.findAllUsingCursor({
       dateBefore,
-      count,
-    )
+      perPage,
+    })
 
-    const result: any = {
+    const result: Entity.ResponseFindAllUsingCursor = {
       data: items,
       meta: {
         next_page: items.length ? items[items.length - 1].created_at : null,

--- a/src/modules/partners/partner_service.ts
+++ b/src/modules/partners/partner_service.ts
@@ -41,7 +41,7 @@ export namespace Partner {
       meta: {
         next_page: items.length ? items[items.length - 1].created_at : null,
         per_page: items.length || 0,
-        last_update: lastUpdate?.created_at || null,
+        last_update: items.length ? (lastUpdate?.created_at || null) : null
       }
     }
 

--- a/src/modules/partners/partner_service.ts
+++ b/src/modules/partners/partner_service.ts
@@ -36,6 +36,7 @@ export namespace Partner {
       data: items,
       meta: {
         next_page: items.length ? items[items.length - 1].created_at : null,
+        per_page: items.length || 0,
       }
     }
 

--- a/src/modules/partners/partner_service.ts
+++ b/src/modules/partners/partner_service.ts
@@ -29,21 +29,21 @@ export namespace Partner {
     const perPage = Number(requestQuery?.per_page) || 6
 
     const lastUpdate = await Repository.getLastUpdate()
-
     const items: any = await Repository.findAllUsingCursor({
       name,
       dateBefore,
       perPage,
     })
+    const itemsLength = items.length
 
     const result: Entity.ResponseFindAllUsingCursor = {
       data: items,
       meta: {
-        next_page: items.length ? items[items.length - 1].created_at : null,
-        per_page: items.length || 0,
-        last_update: items.length ? (lastUpdate?.created_at || null) : null
-      }
-    }
+        next_page: itemsLength ? items[itemsLength - 1].created_at : null,
+        per_page: itemsLength || 0,
+        last_update: (itemsLength && lastUpdate.created_at) ? lastUpdate.created_at : null,
+      },
+    };
 
     return result
   }

--- a/src/modules/partners/partner_service.ts
+++ b/src/modules/partners/partner_service.ts
@@ -23,6 +23,25 @@ export namespace Partner {
     return result
   }
 
+  export const findAllUsingCursor = async (requestQuery: Entity.RequestQueryUsingCursor): Promise<any> => {
+    const dateBefore = requestQuery?.date_before ? new Date(requestQuery.date_before) : new Date()
+    const count = +requestQuery?.count || 6
+
+    const items: any = await Repository.findAllUsingCursor(
+      dateBefore,
+      count,
+    )
+
+    const result: any = {
+      data: items,
+      meta: {
+        next_page: items.length ? items[items.length - 1].created_at : null,
+      }
+    }
+
+    return result
+  }
+
   export const search = async (requestQuery: Entity.RequestQuerySuggestion): Promise<Entity.ResponseSuggestion> => {
     const partners: Entity.PartnerSuggestion[] = requestQuery?.name?.length >= 3 ? await Repository.search(requestQuery) : []
 

--- a/src/modules/partners/partner_service.ts
+++ b/src/modules/partners/partner_service.ts
@@ -24,10 +24,12 @@ export namespace Partner {
   }
 
   export const findAllUsingCursor = async (requestQuery: Entity.RequestQueryUsingCursor): Promise<Entity.ResponseFindAllUsingCursor> => {
+    const name = requestQuery.name
     const dateBefore = requestQuery?.next_page ? new Date(requestQuery.next_page) : new Date()
     const perPage = Number(requestQuery?.per_page) || 6
 
     const items: any = await Repository.findAllUsingCursor({
+      name,
       dateBefore,
       perPage,
     })


### PR DESCRIPTION
# Background
- Pagination is slow. ref: https://youtu.be/53MNk1hmRTw
- Query using cursor may improve query performance

## Need to be Discussed
- Do we need to create index on the `created_at` column? @tukangremot Since it may improve the performance much further.
  - ref:
    - https://stackoverflow.com/a/9087929/13276861
    - https://www.toolbox.com/tech/data-management/question/should-timestamps-be-in-an-index-063010/

cc: @jabardigitalservice/jds-backend

# Evidence
- title: query partners using cursor query
- project: Desa Digital
- participants:  @firmanJS @ayocodingit @tukangremot