### PR TITLE
sprint-2: add total in meta query

### DIFF
--- a/src/modules/partners/partner_entity.ts
+++ b/src/modules/partners/partner_entity.ts
@@ -48,6 +48,7 @@ export namespace Partner {
       next_page: string
       per_page: number
       last_update?: Date
+      total: number
     }
   }
 

--- a/src/modules/partners/partner_entity.ts
+++ b/src/modules/partners/partner_entity.ts
@@ -33,6 +33,10 @@ export namespace Partner {
     perPage: number
   }
 
+  export interface MetaQueryUsingCursor {
+    name: string
+  }
+
   interface Meta extends metaPaginate {
     last_update?: Date
   }

--- a/src/modules/partners/partner_repository.ts
+++ b/src/modules/partners/partner_repository.ts
@@ -26,25 +26,31 @@ export namespace Partner {
     return query
   }
 
+  export const metaUsingCursor = (requestQuery: Entity.MetaQueryUsingCursor) => {
+    const total = Partners()
+      .count('id', { as: 'total' })
+      .first()
+    if (requestQuery.name) total.where('name', requestQuery.name);
+
+    const lastUpdate = Partners()
+      .select('created_at')
+      .orderBy('created_at', 'desc')
+      .first()
+
+    return { total, lastUpdate }
+  }
+
   export const findAllUsingCursor = (requestQuery: Entity.QueryUsingCursor) => {
     const query = Partners()
+      .select('id', 'name', 'total_village', 'logo', 'created_at', 'website')
       .whereNull('deleted_at')
+      .where('created_at', '<', requestQuery.dateBefore)
       .orderBy('created_at', 'desc')
+      .limit(requestQuery.perPage)
 
     if (requestQuery.name) query.where('name', requestQuery.name)
 
-    const meta = query.clone()
-      .select(database.raw('COUNT(id) AS total'))
-      .first()
-
-    query.limit(requestQuery.perPage)
-      .select('id', 'name', 'total_village', 'logo', 'created_at', 'website')
-      .where('created_at', '<', requestQuery.dateBefore)
-
-    return {
-      items: query,
-      meta,
-    }
+    return query
   }
 
   export const search = (requestQuery: Entity.RequestQuerySuggestion) => {

--- a/src/modules/partners/partner_repository.ts
+++ b/src/modules/partners/partner_repository.ts
@@ -21,8 +21,8 @@ export namespace Partner {
       .select('created_at', 'total')
       .from(
         database.raw(
-          'partners, (SELECT count(*) AS total FROM partners) AS tmp'
-        )
+          'partners, (SELECT count(*) AS total FROM partners) AS tmp',
+        ),
       ).whereNull('deleted_at')
       .orderBy('created_at', 'desc')
       .first()

--- a/src/modules/partners/partner_repository.ts
+++ b/src/modules/partners/partner_repository.ts
@@ -16,10 +16,14 @@ export namespace Partner {
     return query.paginate(pagination(requestQuery))
   }
 
-  export const getLastUpdate = () => {
-    const query = Partners()
-      .select('created_at')
-      .whereNull('deleted_at')
+  export const getMeta = () => {
+    const query = database
+      .select('created_at', 'total')
+      .from(
+        database.raw(
+          'partners, (SELECT count(*) AS total FROM partners) AS tmp'
+        )
+      ).whereNull('deleted_at')
       .orderBy('created_at', 'desc')
       .first()
 

--- a/src/modules/partners/partner_service.ts
+++ b/src/modules/partners/partner_service.ts
@@ -37,12 +37,12 @@ export namespace Partner {
     const result: Entity.ResponseFindAllUsingCursor = {
       data: items,
       meta: {
-        next_page: itemsLength ? items[itemsLength - 1].created_at.toISOString() : null,
+        next_page: itemsLength ? items[itemsLength - 1].created_at : null,
         per_page: perPage,
         last_update: meta?.created_at || null,
         total: meta?.total,
       },
-    };
+    }
 
     return result
   }

--- a/src/modules/partners/partner_service.ts
+++ b/src/modules/partners/partner_service.ts
@@ -10,7 +10,7 @@ export namespace Partner {
       current_page: requestQuery.current_page,
     })
 
-    const lastUpdate = await Repository.getLastUpdate()
+    const lastUpdate = await Repository.getMeta()
 
     const result: Entity.ResponseFindAll = {
       data: items.data,
@@ -28,7 +28,7 @@ export namespace Partner {
     const dateBefore = requestQuery?.next_page ? new Date(requestQuery.next_page) : new Date()
     const perPage = Number(requestQuery?.per_page) || 6
 
-    const lastUpdate = await Repository.getLastUpdate()
+    const lastUpdate = await Repository.getMeta()
     const items: any = await Repository.findAllUsingCursor({
       name,
       dateBefore,
@@ -42,6 +42,7 @@ export namespace Partner {
         next_page: itemsLength ? items[itemsLength - 1].created_at : null,
         per_page: itemsLength || 0,
         last_update: (itemsLength && lastUpdate.created_at) ? lastUpdate.created_at : null,
+        total: lastUpdate?.total || 0,
       },
     };
 

--- a/src/modules/partners/partner_service.ts
+++ b/src/modules/partners/partner_service.ts
@@ -38,9 +38,9 @@ export namespace Partner {
       data: items,
       meta: {
         next_page: itemsLength ? items[itemsLength - 1].created_at.toISOString() : null,
-        per_page: itemsLength || 0,
+        per_page: perPage,
         last_update: meta?.created_at || null,
-        total: meta?.total || 0,
+        total: meta?.total,
       },
     };
 

--- a/src/modules/partners/partner_service.ts
+++ b/src/modules/partners/partner_service.ts
@@ -38,7 +38,7 @@ export namespace Partner {
     const result: Entity.ResponseFindAllUsingCursor = {
       data: items,
       meta: {
-        next_page: itemsLength ? items[itemsLength - 1].created_at.toISOString() : null,
+        next_page: itemsLength ? items[itemsLength - 1].created_at : null,
         per_page: perPage,
         last_update: lastUpdate.created_at || null,
         total: total.total,

--- a/src/modules/partners/partner_service.ts
+++ b/src/modules/partners/partner_service.ts
@@ -28,19 +28,20 @@ export namespace Partner {
     const dateBefore = requestQuery?.next_page ? new Date(requestQuery.next_page) : new Date()
     const perPage = Number(requestQuery?.per_page) || 6
 
-    const query = Repository.findAllUsingCursor({ name, dateBefore, perPage })
-    const items: any = await query.items
-    const meta: any = await query.meta
+    const meta: any = Repository.metaUsingCursor({ name })
+    const items: any = await Repository.findAllUsingCursor({ name, dateBefore, perPage })
+    const total: any = await meta.total
+    const lastUpdate: any = await meta.lastUpdate
 
     const itemsLength = items.length
 
     const result: Entity.ResponseFindAllUsingCursor = {
       data: items,
       meta: {
-        next_page: itemsLength ? items[itemsLength - 1].created_at : null,
+        next_page: itemsLength ? items[itemsLength - 1].created_at.toISOString() : null,
         per_page: perPage,
-        last_update: meta?.created_at || null,
-        total: meta?.total,
+        last_update: lastUpdate.created_at || null,
+        total: total.total,
       },
     }
 

--- a/src/modules/partners/partner_service.ts
+++ b/src/modules/partners/partner_service.ts
@@ -10,7 +10,7 @@ export namespace Partner {
       current_page: requestQuery.current_page,
     })
 
-    const lastUpdate = await Repository.getMeta()
+    const lastUpdate = await Repository.getLastUpdate()
 
     const result: Entity.ResponseFindAll = {
       data: items.data,
@@ -28,21 +28,19 @@ export namespace Partner {
     const dateBefore = requestQuery?.next_page ? new Date(requestQuery.next_page) : new Date()
     const perPage = Number(requestQuery?.per_page) || 6
 
-    const lastUpdate = await Repository.getMeta()
-    const items: any = await Repository.findAllUsingCursor({
-      name,
-      dateBefore,
-      perPage,
-    })
+    const query = Repository.findAllUsingCursor({ name, dateBefore, perPage })
+    const items: any = await query.items
+    const meta: any = await query.meta
+
     const itemsLength = items.length
 
     const result: Entity.ResponseFindAllUsingCursor = {
       data: items,
       meta: {
-        next_page: itemsLength ? items[itemsLength - 1].created_at : null,
+        next_page: itemsLength ? items[itemsLength - 1].created_at.toISOString() : null,
         per_page: itemsLength || 0,
-        last_update: (itemsLength && lastUpdate.created_at) ? lastUpdate.created_at : null,
-        total: lastUpdate?.total || 0,
+        last_update: meta?.created_at || null,
+        total: meta?.total || 0,
       },
     };
 


### PR DESCRIPTION
## Overview
- Change `getLastUpdate` method name to `getMeta`
- Add `total` in the query

cc @jabardigitalservice/jds-backend 

## Evidence
title: add total in meta query
project: Desa Digital
participants:  @firmanJS @ayocodingit 