### PR TITLE
feat: add module districts with location

### DIFF
--- a/src/database/migrations/20211008033943_create_table_districts.ts
+++ b/src/database/migrations/20211008033943_create_table_districts.ts
@@ -9,6 +9,7 @@ export async function up(knex: Knex): Promise<void> {
         table.string('city_id', 5).notNullable().index()
         table.boolean('is_active').notNullable().index()
         table.string('area_id', 4).index()
+        table.specificType('location', 'POINT').notNullable().index()
       })
     }
   })

--- a/src/modules/districts/district_entity.ts
+++ b/src/modules/districts/district_entity.ts
@@ -1,0 +1,39 @@
+import { Query } from '../../helpers/types';
+
+export namespace District {
+  export interface Struct {
+    id: string
+    name: string
+    city_id: string
+    is_active: boolean
+    area_id?: string
+    location: any
+  }
+
+  export interface WithLocation {
+    id: string
+    name: string
+    city: {
+      id: string
+      name: string
+    }
+    location: {
+      lat: number
+      lng: number
+    },
+  }
+
+  export interface RequestQueryWithLocation extends Query {
+    bounds: {
+      ne: string
+      sw: string
+    }
+  }
+
+  export interface ResponseWithLocation {
+    data: WithLocation[]
+    meta: {
+      total: number
+    }
+  }
+}

--- a/src/modules/districts/district_handler.ts
+++ b/src/modules/districts/district_handler.ts
@@ -1,0 +1,17 @@
+import express, { Request, Response, NextFunction } from 'express'
+import httpStatus from 'http-status'
+import { District as Entity } from './district_entity'
+import { District as Service } from './district_service';
+
+const router = express.Router()
+
+router.get(
+  '/v1/districts/with-location',
+  async (req: Request<never, never, never, Entity.RequestQueryWithLocation>, res: Response, next: NextFunction) => {
+    const result: Entity.ResponseWithLocation = await Service.withLocation(req.query)
+
+    res.status(httpStatus.OK).json(result)
+  },
+)
+
+export default router

--- a/src/modules/districts/district_repository.ts
+++ b/src/modules/districts/district_repository.ts
@@ -1,0 +1,54 @@
+import database from '../../config/database';
+import { District as Entity } from './district_entity';
+
+export namespace District {
+  const getPolygon = (requestQuery: Entity.RequestQueryWithLocation) => {
+    const { ne, sw } = requestQuery.bounds
+
+    const boundsNE = ne.trimStart().trimEnd().split(/[, ]+/)
+    const boundsSW = sw.trimStart().trimEnd().split(/[, ]+/)
+
+    return `POLYGON((
+      ${boundsNE[0]} ${boundsNE[1]},
+      ${boundsNE[0]} ${boundsSW[1]},
+      ${boundsSW[0]} ${boundsSW[1]},
+      ${boundsSW[0]} ${boundsNE[1]},
+      ${boundsNE[0]} ${boundsNE[1]}
+    ))`
+  }
+
+  const getWherePolygon = (requestQuery: Entity.RequestQueryWithLocation) => {
+    const wherePolygon = `ST_CONTAINS(ST_GEOMFROMTEXT('${getPolygon(requestQuery)}'), districts.location)`
+
+    return wherePolygon
+  }
+
+  export const Districts = () => database<Entity.Struct>('districts')
+
+  export const withLocation = (requestQuery: Entity.RequestQueryWithLocation) => {
+    const query = Districts()
+      .select(
+        'districts.id',
+        'districts.name',
+        'districts.location',
+        'cities.id as cities_id',
+        'cities.name as cities_name',
+      )
+      .leftJoin('cities', 'cities.id', '=', 'districts.city_id')
+      .where('districts.is_active', true)
+      .orderBy('districts.name', 'asc')
+
+    query.whereRaw(getWherePolygon(requestQuery))
+
+    return query
+  }
+
+  export const getTotalWithLocation = () => {
+    const query = Districts()
+      .count('id', { as: 'total' })
+      .where('is_active', true)
+      .first()
+
+    return query
+  }
+}

--- a/src/modules/districts/district_rules.ts
+++ b/src/modules/districts/district_rules.ts
@@ -1,0 +1,1 @@
+export namespace District {}

--- a/src/modules/districts/district_service.ts
+++ b/src/modules/districts/district_service.ts
@@ -1,0 +1,48 @@
+import { District as Entity } from './district_entity'
+import { District as Repository } from './district_repository'
+
+export namespace District {
+  const pointRegexRule = (point: string) => {
+    const pointRegex = /^(-?\d+(\.\d+)?),\s*(-?\d+(\.\d+)?)$/
+    return pointRegex.test(point)
+  }
+
+  const isRequestBounds = (requestQuery: Entity.RequestQueryWithLocation) => requestQuery?.bounds?.ne
+    && requestQuery?.bounds?.sw
+    && pointRegexRule(requestQuery.bounds.ne)
+    && pointRegexRule(requestQuery.bounds.sw)
+
+  const responseWithLocation = (items: any[]): Entity.WithLocation[] => {
+    const data: Entity.WithLocation[] = []
+    for (const item of items) {
+      data.push({
+        id: item.id,
+        name: item.name,
+        city: {
+          id: item.cities_id,
+          name: item.cities_name,
+        },
+        location: {
+          lat: item.location.y,
+          lng: item.location.x,
+        },
+      })
+    }
+
+    return data
+  }
+
+  export const withLocation = async (requestQuery: Entity.RequestQueryWithLocation): Promise<Entity.ResponseWithLocation> => {
+    const items: any = isRequestBounds(requestQuery) ? await Repository.withLocation(requestQuery) : []
+    const total: any = await Repository.getTotalWithLocation()
+
+    const result: Entity.ResponseWithLocation = {
+      data: responseWithLocation(items),
+      meta: {
+        total: total.total,
+      },
+    }
+
+    return result
+  }
+}

--- a/src/modules/districts/district_test.ts
+++ b/src/modules/districts/district_test.ts
@@ -1,0 +1,48 @@
+import request from 'supertest'
+import app from '../../server'
+import { District as Repository } from './district_repository'
+import database from '../../config/database'
+
+describe('seed data', () => {
+  it('insert districts', async () => {
+    await Repository.Districts().insert({
+      id: '12345678',
+      name: 'test123',
+      city_id: '12345',
+      location: database.raw('ST_GeomFromText(\'POINT(107.5090974 -6.8342172)\')'),
+      is_active: true,
+    })
+  })
+})
+
+const expectBodyFindAll = expect.arrayContaining([
+  expect.objectContaining({
+    id: expect.any(String),
+    name: expect.any(String),
+    city: expect.any(Object),
+    location: expect.objectContaining({
+      lat: expect.any(Number),
+      lng: expect.any(Number),
+    }),
+  }),
+])
+
+describe('tests districts', () => {
+  it('test success with location', async () => request(app)
+    .get('/v1/districts/with-location')
+    .query({
+      bounds: {
+        sw: '107.4312207548229,-7.044551821267334',
+        ne: '107.78594184930455,-6.79575221317816',
+      },
+    })
+    .expect(200)
+    .then((response) => {
+      expect(response.body).toEqual(expect.objectContaining({
+        data: expectBodyFindAll,
+        meta: expect.objectContaining({
+          total: expect.any(Number),
+        }),
+      }))
+    }))
+})

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,7 @@ import config from './config'
 import home from './handler/home'
 import partners from './modules/partners/partner_handler'
 import villages from './modules/villages/village_handler'
+import districts from './modules/districts/district_handler'
 import cities from './modules/cities/city_handler'
 import testimonials from './modules/testimonials/testimonial_handler'
 import auth from './modules/auth/auth_handler'
@@ -39,6 +40,7 @@ class App {
     this.app.use(partners)
     this.app.use(villages)
     this.app.use(cities)
+    this.app.use(districts)
     this.app.use(testimonials)
     this.app.use(auth)
   }


### PR DESCRIPTION
## Overview

- add module districts with location 
- endpoint: `/v1/districts/with-location`

![image](https://user-images.githubusercontent.com/41193120/143520602-aaabc452-54db-44f2-82b5-78fe48f67205.png)


cc: @jabardigitalservice/jds-backend 

## Evidence
- title: add module districts with location 
- project: Desa Digital
- participants: @ayocodingit @tukangremot @firmanJS 
