### PR TITLE
improve verify refresh token expired

### DIFF
--- a/src/modules/auth/auth_repository.ts
+++ b/src/modules/auth/auth_repository.ts
@@ -59,11 +59,14 @@ export namespace Auth {
     .first()
 
   export const findByRefreshToken = async (requestBody: Entity.RequestBodyRefreshToken) => OauthTokens()
-    .select('users.id', 'partner_id', 'is_admin')
+    .select('users.id', 'partner_id', 'is_admin', 'is_active')
     .join('users', 'users.id', 'oauth_tokens.user_id')
-    .where('is_active', true)
     .where('refresh_token', requestBody.refresh_token)
     .first()
+
+  export const deleteByRefreshToken = async (requestBody: Entity.RequestBodyRefreshToken) => OauthTokens()
+    .where('refresh_token', requestBody.refresh_token)
+    .delete()
 
   export const createOauthToken = async (oauthToken: Entity.StructOauthToken) => {
     const timestamp = new Date()

--- a/src/modules/auth/auth_repository.ts
+++ b/src/modules/auth/auth_repository.ts
@@ -64,7 +64,7 @@ export namespace Auth {
     .where('refresh_token', requestBody.refresh_token)
     .first()
 
-  export const deleteByRefreshToken = async (requestBody: Entity.RequestBodyRefreshToken) => OauthTokens()
+  export const deleteRefreshToken = async (requestBody: Entity.RequestBodyRefreshToken) => OauthTokens()
     .where('refresh_token', requestBody.refresh_token)
     .delete()
 

--- a/src/modules/auth/auth_repository.ts
+++ b/src/modules/auth/auth_repository.ts
@@ -64,7 +64,7 @@ export namespace Auth {
     .where('refresh_token', requestBody.refresh_token)
     .first()
 
-  export const deleteRefreshToken = async (requestBody: Entity.RequestBodyRefreshToken) => OauthTokens()
+  export const deleteOauthbyRefreshToken = async (requestBody: Entity.RequestBodyRefreshToken) => OauthTokens()
     .where('refresh_token', requestBody.refresh_token)
     .delete()
 

--- a/src/modules/auth/auth_service.ts
+++ b/src/modules/auth/auth_service.ts
@@ -78,7 +78,7 @@ export namespace Auth {
   }
 
   const throwRefreshTokenFailed = async (requestBody: Entity.RequestBodyRefreshToken) => {
-    Repository.deleteByRefreshToken(requestBody)
+    Repository.deleteRefreshToken(requestBody)
     throw new HttpError(httpStatus.UNPROCESSABLE_ENTITY, lang.__('auth.refreshToken.failed'))
   }
 

--- a/src/modules/auth/auth_service.ts
+++ b/src/modules/auth/auth_service.ts
@@ -78,7 +78,7 @@ export namespace Auth {
   }
 
   const throwRefreshTokenFailed = async (requestBody: Entity.RequestBodyRefreshToken) => {
-    Repository.deleteRefreshToken(requestBody)
+    Repository.deleteOauthbyRefreshToken(requestBody)
     throw new HttpError(httpStatus.UNPROCESSABLE_ENTITY, lang.__('auth.refreshToken.failed'))
   }
 

--- a/src/modules/auth/auth_service.ts
+++ b/src/modules/auth/auth_service.ts
@@ -1,6 +1,7 @@
 import httpStatus from 'http-status'
 import bcrypt from 'bcrypt'
 import { Request } from 'express'
+import { verify } from 'jsonwebtoken'
 import { HttpError } from '../../handler/exception'
 import { checkError, uniqueRule } from '../../helpers/rules'
 import lang from '../../lang'
@@ -76,9 +77,28 @@ export namespace Auth {
     return responseJwt
   }
 
+  const throwRefreshTokenFailed = async (requestBody: Entity.RequestBodyRefreshToken) => {
+    Repository.deleteByRefreshToken(requestBody)
+    throw new HttpError(httpStatus.UNPROCESSABLE_ENTITY, lang.__('auth.refreshToken.failed'))
+  }
+
+  const verifyRefreshToken = async (requestBody: Entity.RequestBodyRefreshToken) => {
+    try {
+      verify(requestBody.refresh_token, config.get('jwt.refresh.public'), {
+        algorithms: config.get('jwt.refresh.algorithm'),
+      });
+    } catch (err) {
+      await throwRefreshTokenFailed(requestBody)
+    }
+  }
+
   export const refreshToken = async (requestBody: Entity.RequestBodyRefreshToken) => {
-    const user: Entity.StructUser = await Repository.findByRefreshToken(requestBody)
+    const user: any = await Repository.findByRefreshToken(requestBody)
     if (!user) throw new HttpError(httpStatus.UNPROCESSABLE_ENTITY, lang.__('auth.refreshToken.failed'))
+
+    if (!user.is_active) await throwRefreshTokenFailed(requestBody)
+
+    await verifyRefreshToken(requestBody)
 
     const responseJwt = generateJwtToken(user)
 


### PR DESCRIPTION
# Overview

- improve verify refresh token expired
- remove oauth token when refresh token expired
- implementation token refresh time must be 2 times longer than token time (TBD reference)

cc: @jabardigitalservice/jds-backend 

## Evidence
- title: improve verify refresh token expired
- project: Desa Digital
- participants: @ayocodingit @firmanJS @tukangremot 


