### PR TITLE
feat: add helpers validate with database

### DIFF
--- a/src/helpers/rbac.ts
+++ b/src/helpers/rbac.ts
@@ -1,7 +1,7 @@
 import { AccessControl } from 'accesscontrol';
 import config from '../config';
 
-interface AccessControlStruct {
+export interface AccessControlStruct {
   role: string
   resource: string
   action: string

--- a/src/helpers/rules.ts
+++ b/src/helpers/rules.ts
@@ -1,63 +1,8 @@
-import httpStatus from 'http-status'
-import database from '../config/database'
-import { HttpError } from '../handler/exception'
-import { message } from './validator'
+const unique = (item: object) => !!item
 
-interface rulesInterface {
-  isError: boolean,
-  errors?: {
-    [key: string]: string
-  }
-}
+const exists = (item: object) => !item
 
-interface propertyData {
-  table: string
-  key: string
-  value: string
-  primaryKey?: string,
-  primaryKeyValue?: string | number,
-  isWhereNullDeletedAt?: boolean
-}
-
-const rules: rulesInterface = {
-  isError: false,
-}
-
-const Data = (data: propertyData) => {
-  const query = database(data.table).where(data.key, data.value)
-  if (data.primaryKey && data.primaryKeyValue) query.whereNot(data.primaryKey, data.primaryKeyValue)
-  if (data.isWhereNullDeletedAt) query.whereNull('deleted_at')
-  return query.first()
-}
-
-export const uniqueRule = async (data: propertyData): Promise<rulesInterface> => {
-  const item: any = await Data(data)
-
-  if (item) {
-    rules.isError = true
-    rules.errors = {
-      [data.key]: message('unique', data.key),
-    }
-  } else rules.isError = false
-
-  return rules
-}
-
-export const existsRule = async (data: propertyData): Promise<rulesInterface> => {
-  const item: any = await Data(data)
-
-  if (!item) {
-    rules.isError = true
-    rules.errors = {
-      [data.key]: message('exists', data.key),
-    }
-  } else rules.isError = false
-
-  return rules
-}
-
-export const checkError = (rule: rulesInterface) => {
-  if (rule.isError) {
-    throw new HttpError(httpStatus.UNPROCESSABLE_ENTITY, JSON.stringify(rule.errors), true)
-  }
+export = {
+  unique,
+  exists,
 }

--- a/src/helpers/validator.ts
+++ b/src/helpers/validator.ts
@@ -84,7 +84,9 @@ export const validateWithDB = (
 ) => async (req: Request, res: Response, next: NextFunction) => {
   const errors: any = {}
   const rules = Object.entries(validation)
-  for (const [Key, Value] of rules) {
+
+  for (let index = 0; index < rules.length; index++) {
+    const [Key, Value] = rules[index]
     const { error, type } = await validateWithDBError(req, Key, Value)
     if (error) errors[Key] = message(type, Key)
   }

--- a/src/helpers/validator.ts
+++ b/src/helpers/validator.ts
@@ -78,17 +78,20 @@ const validateWithDBError = async (req: Request, rule: PropertyWithDB): Promise<
   return isError ? message(rule.type, rule.attr) : null
 }
 
-export const validateWithDB = (
-  validation: ValidationWithDB,
-) => async (req: Request, res: Response, next: NextFunction) => {
+const validateErrorWithDB = async (req: Request, validation: ValidationWithDB) => {
   const errors: any = {}
-
   for (const [_, rules] of Object.entries(validation)) {
     for (const rule of rules) {
       const error = await validateWithDBError(req, rule)
       if (error) errors[rule.attr] = error
     }
   }
+  return errors
+}
 
+export const validateWithDB = (
+  validation: ValidationWithDB,
+) => async (req: Request, res: Response, next: NextFunction) => {
+  const errors = await validateErrorWithDB(req, validation)
   Object.keys(errors).length ? res.status(httpStatus.UNPROCESSABLE_ENTITY).json({ errors }) : next()
 }

--- a/src/helpers/validator.ts
+++ b/src/helpers/validator.ts
@@ -83,8 +83,8 @@ export const validateWithDB = (
   validation: ValidationWithDB,
 ) => async (req: Request, res: Response, next: NextFunction) => {
   const errors: any = {}
-
-  for (const [Key, Value] of Object.entries(validation)) {
+  const rules = Object.entries(validation)
+  for (const [Key, Value] of rules) {
     const { error, type } = await validateWithDBError(req, Key, Value)
     if (error) errors[Key] = message(type, Key)
   }

--- a/src/helpers/validator.ts
+++ b/src/helpers/validator.ts
@@ -78,13 +78,20 @@ const validateWithDBError = async (req: Request, rule: PropertyWithDB): Promise<
   return isError ? message(rule.type, rule.attr) : null
 }
 
+const getErrorWithDB = async (req: Request, rules: PropertyWithDB[]) => {
+  let message: string
+  for (const rule of rules) {
+    const error = await validateWithDBError(req, rule)
+    if (error) message = error
+  }
+  return message
+}
+
 const validateErrorWithDB = async (req: Request, validation: ValidationWithDB) => {
   const errors: any = {}
-  for (const [_, rules] of Object.entries(validation)) {
-    for (const rule of rules) {
-      const error = await validateWithDBError(req, rule)
-      if (error) errors[rule.attr] = error
-    }
+  for (const [key, rules] of Object.entries(validation)) {
+    const error = await getErrorWithDB(req, rules)
+    if (error) errors[key] = error
   }
   return errors
 }

--- a/src/helpers/validator.ts
+++ b/src/helpers/validator.ts
@@ -67,7 +67,7 @@ const Query = async (rule: PropertyWithDB, value: string, primaryKeyValue?: stri
   return query.first()
 }
 
-const validateWithDBError = async (req: Request, rule: PropertyWithDB): Promise<string> => {
+const getErrorWithDB = async (req: Request, rule: PropertyWithDB): Promise<string> => {
   const value: string = req.body[rule.attr]
   const primaryKeyValue = req.params[rule.params] || null
 
@@ -78,10 +78,10 @@ const validateWithDBError = async (req: Request, rule: PropertyWithDB): Promise<
   return isError ? message(rule.type, rule.attr) : null
 }
 
-const getErrorWithDB = async (req: Request, rules: PropertyWithDB[]) => {
+const validateWithDBError = async (req: Request, rules: PropertyWithDB[]) => {
   let message: string
   for (const rule of rules) {
-    const error = await validateWithDBError(req, rule)
+    const error = await getErrorWithDB(req, rule)
     if (error) message = error
   }
   return message
@@ -90,7 +90,7 @@ const getErrorWithDB = async (req: Request, rules: PropertyWithDB[]) => {
 const validateErrorWithDB = async (req: Request, validation: ValidationWithDB) => {
   const errors: any = {}
   for (const [key, rules] of Object.entries(validation)) {
-    const error = await getErrorWithDB(req, rules)
+    const error = await validateWithDBError(req, rules)
     if (error) errors[key] = error
   }
   return errors

--- a/src/modules/auth/auth_http.ts
+++ b/src/modules/auth/auth_http.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express'
 import rateLimit from 'express-rate-limit'
-import { validate } from '../../helpers/validator'
+import { validate, validateWithDB } from '../../helpers/validator'
 import { verifyAccessToken } from '../../middleware/jwt'
 import { Auth as Rules } from './auth_rules'
 import { Auth as Handler } from './auth_handler'
@@ -13,7 +13,7 @@ const apiLimiterSignIn = rateLimit({
 
 const router = Router()
 
-router.post('/v1/auth/users/sign-up', validate(Rules.signUp), Handler.signUp)
+router.post('/v1/auth/users/sign-up', validate(Rules.signUp), validateWithDB(Rules.signUpWithDB), Handler.signUp)
 router.post('/v1/auth/users/sign-in', apiLimiterSignIn, validate(Rules.signIn), Handler.signIn)
 router.post('/v1/auth/users/sign-out', verifyAccessToken, validate(Rules.refreshToken), Handler.signOut)
 router.post('/v1/auth/users/me', verifyAccessToken, Handler.me)

--- a/src/modules/auth/auth_rules.ts
+++ b/src/modules/auth/auth_rules.ts
@@ -39,4 +39,8 @@ export namespace Auth {
   export const resetPassword = Joi.object({
     ...rulesPassword,
   })
+
+  export const signUpWithDB = {
+    email: 'unique:users,email,id',
+  }
 }

--- a/src/modules/auth/auth_rules.ts
+++ b/src/modules/auth/auth_rules.ts
@@ -1,4 +1,5 @@
 import Joi from 'joi';
+import { ValidationWithDB } from '../../helpers/validator';
 
 export namespace Auth {
 
@@ -40,7 +41,11 @@ export namespace Auth {
     ...rulesPassword,
   })
 
-  export const signUpWithDB = {
-    email: 'unique:users,email,id',
+  export const signUpWithDB: ValidationWithDB = {
+    email: [
+      {
+        type: 'unique', attr: 'email', table: 'users', column: 'email',
+      },
+    ],
   }
 }

--- a/src/modules/auth/auth_service.ts
+++ b/src/modules/auth/auth_service.ts
@@ -3,7 +3,6 @@ import bcrypt from 'bcrypt'
 import { Request } from 'express'
 import { verify } from 'jsonwebtoken'
 import { HttpError } from '../../handler/exception'
-import { checkError, uniqueRule } from '../../helpers/rules'
 import lang from '../../lang'
 import { Auth as Entity } from './auth_entity'
 import { Auth as Repository } from './auth_repository'
@@ -15,12 +14,6 @@ import { convertToBoolean } from '../../helpers/constant'
 
 export namespace Auth {
   export const signUp = async (requestBody: Entity.RequestBodySignUp) => {
-    checkError(await uniqueRule({
-      table: 'users',
-      key: 'email',
-      value: requestBody.email,
-    }))
-
     const user: Entity.RequestBodySignUp = {
       name: requestBody.name,
       email: requestBody.email,

--- a/src/modules/pages/page_access.ts
+++ b/src/modules/pages/page_access.ts
@@ -1,9 +1,9 @@
 import config from '../../config'
-import { accessControl } from '../../helpers/rbac'
+import { accessControl, AccessControlStruct } from '../../helpers/rbac'
 import grantAccess from '../../middleware/grantAccess'
 
 export namespace Page {
-  const flatList = [
+  const flatList: AccessControlStruct[] = [
     {
       role: config.get('role.0'), resource: 'page', action: 'read:any', attributes: ['*'],
     },

--- a/src/modules/pages/page_http.ts
+++ b/src/modules/pages/page_http.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express'
 import cache from '../../config/cache';
-import { validate } from '../../helpers/validator';
+import { validate, validateWithDB } from '../../helpers/validator';
 import { verifyAccessToken } from '../../middleware/jwt';
 import { Page as Access } from './page_access';
 import { Page as Handler } from './page_handler';
@@ -10,8 +10,8 @@ const router = Router()
 
 router.get('/v1/pages', cache(), validate(Rules.findAll, 'query'), Handler.findAll)
 router.get('/v1/pages/:id', verifyAccessToken, Access.findById(), Handler.findById)
-router.post('/v1/pages', verifyAccessToken, Access.store(), validate(Rules.store), Handler.store)
+router.post('/v1/pages', verifyAccessToken, Access.store(), validate(Rules.store), validateWithDB(Rules.storeWithDB), Handler.store)
 router.delete('/v1/pages/:id', verifyAccessToken, Access.destroy(), Handler.destroy)
-router.put('/v1/pages/:id', verifyAccessToken, Access.update(), validate(Rules.update), Handler.update)
+router.put('/v1/pages/:id', verifyAccessToken, Access.update(), validate(Rules.update), validateWithDB(Rules.updateWithDB), Handler.update)
 
 export default router

--- a/src/modules/pages/page_rules.ts
+++ b/src/modules/pages/page_rules.ts
@@ -1,4 +1,5 @@
 import Joi from 'joi';
+import { ValidationWithDB } from '../../helpers/validator';
 
 export namespace Page {
   const orderByValid = ['title', 'is_active']
@@ -20,8 +21,12 @@ export namespace Page {
   export const store = validate
   export const update = validate
 
-  const validateWithDB = {
-    title: 'unique:pages,title,id',
+  const validateWithDB: ValidationWithDB = {
+    title: [
+      {
+        type: 'unique', attr: 'title', table: 'pages', column: 'title', params: 'id',
+      },
+    ],
   }
 
   export const storeWithDB = validateWithDB

--- a/src/modules/pages/page_rules.ts
+++ b/src/modules/pages/page_rules.ts
@@ -19,4 +19,11 @@ export namespace Page {
 
   export const store = validate
   export const update = validate
+
+  const validateWithDB = {
+    title: 'unique:pages,title,id',
+  }
+
+  export const storeWithDB = validateWithDB
+  export const updateWithDB = validateWithDB
 }

--- a/src/modules/pages/page_test.ts
+++ b/src/modules/pages/page_test.ts
@@ -46,10 +46,10 @@ const accessToken = createAccessToken({
   adm: true,
 })
 
-const title = faker.lorem.slug(2)
+const title = () => faker.lorem.slug(2)
 
 const data = (): Entity.RequestBody => ({
-  title,
+  title: title(),
   description: faker.lorem.paragraph(),
   is_active: 'true',
   filename: faker.image.image(),


### PR DESCRIPTION
# Overview

- feat: add helpers validate with database
- use validate unique in store and update (pages)
- use validate unique in signup (auth)
- update export interface AccessControlStruct

## Evidence
- title: feat: add helpers validate with database
- project: Desa Digital
- participants: @ayocodingit 