### PR TITLE
feat: api test modules city and district

### DIFF
--- a/src/modules/cities/city_service.ts
+++ b/src/modules/cities/city_service.ts
@@ -7,8 +7,8 @@ export namespace City {
     return pointRegex.test(point)
   }
 
-  const isRequestBounds = (requestQuery: Entity.RequestQueryWithLocation) => requestQuery?.bounds?.ne
-    && requestQuery?.bounds?.sw
+  const isRequestBounds = (requestQuery: Entity.RequestQueryWithLocation) => requestQuery.bounds?.ne
+    && requestQuery.bounds.sw
     && pointRegexRule(requestQuery.bounds.ne)
     && pointRegexRule(requestQuery.bounds.sw)
 

--- a/src/modules/cities/city_test.ts
+++ b/src/modules/cities/city_test.ts
@@ -1,4 +1,5 @@
 import request from 'supertest'
+import httpStatus from 'http-status'
 import app from '../../server'
 import { City as Repository } from './city_repository'
 import database from '../../config/database'
@@ -14,7 +15,7 @@ describe('seed data', () => {
   })
 })
 
-const expectBodyFindAll = expect.arrayContaining([
+const expectFindAll = expect.arrayContaining([
   expect.objectContaining({
     id: expect.any(String),
     name: expect.any(String),
@@ -25,8 +26,22 @@ const expectBodyFindAll = expect.arrayContaining([
   }),
 ])
 
+const expectMeta = expect.objectContaining({
+  total: expect.any(Number),
+})
+
+const expectBodyFindAll = expect.objectContaining({
+  data: expectFindAll,
+  meta: expectMeta,
+})
+
+const expectEmptyBodyFindAll = expect.objectContaining({
+  data: [],
+  meta: expectMeta,
+})
+
 describe('tests cities', () => {
-  it('test success findAll with location filter bounds', async () => request(app)
+  it('test success findAll', async () => request(app)
     .get('/v1/cities/with-location')
     .query({
       bounds: {
@@ -34,13 +49,31 @@ describe('tests cities', () => {
         ne: '107.78594184930455,-6.79575221317816',
       },
     })
-    .expect(200)
+    .expect(httpStatus.OK)
     .then((response) => {
-      expect(response.body).toEqual(expect.objectContaining({
-        data: expectBodyFindAll,
-        meta: expect.objectContaining({
-          total: expect.any(Number),
-        }),
-      }))
+      expect(response.body).toEqual(expectBodyFindAll)
+    }))
+})
+
+describe('tests cities', () => {
+  it('test success findAll without bound sw', async () => request(app)
+    .get('/v1/cities/with-location')
+    .query({
+      bounds: {
+        ne: '107.78594184930455,-6.79575221317816',
+      },
+    })
+    .expect(httpStatus.OK)
+    .then((response) => {
+      expect(response.body).toEqual(expectEmptyBodyFindAll)
+    }))
+})
+
+describe('tests cities', () => {
+  it('test success findAll without bounds', async () => request(app)
+    .get('/v1/cities/with-location')
+    .expect(httpStatus.OK)
+    .then((response) => {
+      expect(response.body).toEqual(expectEmptyBodyFindAll)
     }))
 })

--- a/src/modules/districts/district_service.ts
+++ b/src/modules/districts/district_service.ts
@@ -7,8 +7,8 @@ export namespace District {
     return pointRegex.test(point)
   }
 
-  const isRequestBounds = (requestQuery: Entity.RequestQueryWithLocation) => requestQuery?.bounds?.ne
-    && requestQuery?.bounds?.sw
+  const isRequestBounds = (requestQuery: Entity.RequestQueryWithLocation) => requestQuery.bounds?.ne
+    && requestQuery.bounds.sw
     && pointRegexRule(requestQuery.bounds.ne)
     && pointRegexRule(requestQuery.bounds.sw)
 

--- a/src/modules/districts/district_test.ts
+++ b/src/modules/districts/district_test.ts
@@ -1,4 +1,5 @@
 import request from 'supertest'
+import httpStatus from 'http-status'
 import app from '../../server'
 import { District as Repository } from './district_repository'
 import database from '../../config/database'
@@ -15,7 +16,7 @@ describe('seed data', () => {
   })
 })
 
-const expectBodyFindAll = expect.arrayContaining([
+const expectFindAll = expect.arrayContaining([
   expect.objectContaining({
     id: expect.any(String),
     name: expect.any(String),
@@ -27,8 +28,22 @@ const expectBodyFindAll = expect.arrayContaining([
   }),
 ])
 
+const expectMeta = expect.objectContaining({
+  total: expect.any(Number),
+})
+
+const expectBodyFindAll = expect.objectContaining({
+  data: expectFindAll,
+  meta: expectMeta,
+})
+
+const expectEmptyBodyFindAll = expect.objectContaining({
+  data: [],
+  meta: expectMeta,
+})
+
 describe('tests districts', () => {
-  it('test success with location', async () => request(app)
+  it('test success find all', async () => request(app)
     .get('/v1/districts/with-location')
     .query({
       bounds: {
@@ -36,13 +51,31 @@ describe('tests districts', () => {
         ne: '107.78594184930455,-6.79575221317816',
       },
     })
-    .expect(200)
+    .expect(httpStatus.OK)
     .then((response) => {
-      expect(response.body).toEqual(expect.objectContaining({
-        data: expectBodyFindAll,
-        meta: expect.objectContaining({
-          total: expect.any(Number),
-        }),
-      }))
+      expect(response.body).toEqual(expectBodyFindAll)
+    }))
+})
+
+describe('tests districts', () => {
+  it('test success find all without bound sw', async () => request(app)
+    .get('/v1/districts/with-location')
+    .query({
+      bounds: {
+        ne: '107.78594184930455,-6.79575221317816',
+      },
+    })
+    .expect(httpStatus.OK)
+    .then((response) => {
+      expect(response.body).toEqual(expectEmptyBodyFindAll)
+    }))
+})
+
+describe('tests districts', () => {
+  it('test success find all without bounds', async () => request(app)
+    .get('/v1/districts/with-location')
+    .expect(httpStatus.OK)
+    .then((response) => {
+      expect(response.body).toEqual(expectEmptyBodyFindAll)
     }))
 })


### PR DESCRIPTION
# Overview

feat: api test modules city and district

coverage result: 
- api test module `city` (before)
![image](https://user-images.githubusercontent.com/41193120/147907638-16c3b862-5581-48b1-b3b4-466bb1cfdf74.png)

- api test module `district` (before)
![image](https://user-images.githubusercontent.com/41193120/147907608-b1d88f8a-f743-439c-a281-210936c5b151.png)

- api test module `city` (after)
![image](https://user-images.githubusercontent.com/41193120/147907361-af88eef8-3c5f-4c91-ba82-472d2216dcf8.png)
- api test module `district` (after)
![image](https://user-images.githubusercontent.com/41193120/147907477-f9f63c2c-c287-4269-921d-b26e678df978.png)