### PR TITLE
feat: add field order (pages)

### DIFF
--- a/src/database/migrations/20211221034605_create_table_pages.ts
+++ b/src/database/migrations/20211221034605_create_table_pages.ts
@@ -8,6 +8,7 @@ export async function up(knex: Knex): Promise<void> {
         table.uuid('created_by').notNullable().index()
         table.string('title', 70).notNullable().index()
         table.string('link').notNullable()
+        table.integer('order').index()
         table.boolean('is_active').defaultTo(true).index()
         table.string('image').notNullable()
         table.timestamp('created_at').notNullable()

--- a/src/modules/pages/page_entity.ts
+++ b/src/modules/pages/page_entity.ts
@@ -7,6 +7,7 @@ export namespace Page {
     created_by?: string
     title: string
     link: string
+    order: number
     is_active: boolean
     image: string
     created_at?: Date
@@ -45,6 +46,7 @@ export namespace Page {
     title: string
     link: string
     is_active: boolean
+    order: number
     image: string
     image_original_name: string
   }

--- a/src/modules/pages/page_rules.ts
+++ b/src/modules/pages/page_rules.ts
@@ -2,7 +2,7 @@ import Joi from 'joi';
 import { ValidationWithDB } from '../../helpers/validator';
 
 export namespace Page {
-  const orderByValid = ['title', 'is_active', 'updated_at']
+  const orderByValid = ['title', 'is_active', 'updated_at', 'order']
   const emptyAllow = ['', null]
 
   export const findAll = Joi.object({
@@ -13,6 +13,7 @@ export namespace Page {
   const validate = Joi.object({
     title: Joi.string().max(70).required(),
     link: Joi.string().uri().max(255).required(),
+    order: Joi.number().required(),
     is_active: Joi.boolean().required(),
     image: Joi.string().max(255).required(),
     image_original_name: Joi.string().max(255).required(),

--- a/src/modules/pages/page_rules.ts
+++ b/src/modules/pages/page_rules.ts
@@ -2,7 +2,7 @@ import Joi from 'joi';
 import { ValidationWithDB } from '../../helpers/validator';
 
 export namespace Page {
-  const orderByValid = ['title', 'is_active', 'updated_at', 'order']
+  const orderByValid = ['title', 'is_active', 'updated_at', 'order', 'created_at']
   const emptyAllow = ['', null]
 
   export const findAll = Joi.object({

--- a/src/modules/pages/page_service.ts
+++ b/src/modules/pages/page_service.ts
@@ -61,6 +61,7 @@ export namespace Page {
     return Repository.store({
       created_by: user.identifier,
       title: requestBody.title,
+      order: requestBody.order,
       link: requestBody.link,
       is_active: convertToBoolean(requestBody.is_active),
       image: requestBody.image,
@@ -86,6 +87,7 @@ export namespace Page {
     return Repository.update({
       title: requestBody.title,
       link: requestBody.link,
+      order: requestBody.order,
       is_active: convertToBoolean(requestBody.is_active),
       image: requestBody.image,
     }, item.id)

--- a/src/modules/pages/page_test.ts
+++ b/src/modules/pages/page_test.ts
@@ -47,12 +47,13 @@ const accessToken = createAccessToken({
 })
 
 const title = faker.lorem.slug(2)
+const image = faker.image.image()
 
 const data = (): Entity.RequestBody => ({
   title,
   link: faker.internet.url(),
   is_active: true,
-  image: faker.image.image(),
+  image,
   order: faker.datatype.number(10),
   image_original_name: faker.image.image(),
 })

--- a/src/modules/pages/page_test.ts
+++ b/src/modules/pages/page_test.ts
@@ -53,6 +53,7 @@ const data = (): Entity.RequestBody => ({
   link: faker.internet.url(),
   is_active: true,
   image: faker.image.image(),
+  order: faker.datatype.number(10),
   image_original_name: faker.image.image(),
 })
 

--- a/src/modules/testimonials/testimonial_test.ts
+++ b/src/modules/testimonials/testimonial_test.ts
@@ -11,6 +11,7 @@ import { Testimonial as Entity } from './testimonial_entity'
 
 const isActive = faker.random.arrayElement(['true', 'false'])
 const type = faker.random.arrayElement([config.get('role.1'), config.get('role.2')])
+const avatar = faker.image.image()
 const partnerId = uuidv4()
 const villageId = '123456788'
 
@@ -45,7 +46,7 @@ describe('seed data', () => {
 const data = (): Entity.RequestBody => ({
   name: faker.name.firstName(),
   description: faker.lorem.paragraph(),
-  avatar: faker.image.avatar(),
+  avatar,
   avatar_original_name: faker.image.avatar(),
   type,
   is_active: isActive,


### PR DESCRIPTION
# Overview

- feat: add field order (pages)
<img width="458" alt="gambar" src="https://user-images.githubusercontent.com/41193120/150762163-ec1aa604-39c7-4a42-add0-d6daf55e7231.png">
- add sort by created_at
- add api test condition store file exists (pages & testimonials)

cc: @jabardigitalservice/jds-backend @sandisunandar99 

## Evidence
- title: feat: add field order (pages)
- project: Desa Digital
- participants: @ayocodingit @indraprasetya154 @rachadiannovansyah @sandisunandar99 @rizkyrmsyah @samudra-ajri 

