### PR TITLE
refactor: modify method to class (Pages & Districts)

### DIFF
--- a/src/modules/districts/district_access.ts
+++ b/src/modules/districts/district_access.ts
@@ -1,1 +1,1 @@
-export namespace District {}
+export namespace DistrictAccess {}

--- a/src/modules/districts/district_entity.ts
+++ b/src/modules/districts/district_entity.ts
@@ -1,4 +1,3 @@
-import database from '../../config/database'
 import { Query } from '../../helpers/types'
 
 export namespace District {
@@ -10,8 +9,6 @@ export namespace District {
     area_id?: string
     location: any
   }
-
-  export const Districts = () => database<Struct>('districts')
 
   export interface WithLocation {
     id: string

--- a/src/modules/districts/district_handler.ts
+++ b/src/modules/districts/district_handler.ts
@@ -1,25 +1,29 @@
-import { Request, Response, NextFunction } from 'express'
+import { Request, Response } from 'express'
 import httpStatus from 'http-status'
 import { District as Entity } from './district_entity'
-import { District as Service } from './district_service'
+import { DistrictService } from './district_service'
 
-export namespace District {
-  export const withLocation = async (
+export class DistrictHandler {
+  private districtService: DistrictService
+
+  constructor(districtService: DistrictService = new DistrictService()) {
+    this.districtService = districtService
+  }
+
+  public withLocation = async (
     req: Request<never, never, never, Entity.RequestQueryWithLocation>,
-    res: Response,
-    next: NextFunction
+    res: Response
   ) => {
-    const result: Entity.ResponseWithLocation = await Service.withLocation(req.query)
+    const result: Entity.ResponseWithLocation = await this.districtService.withLocation(req.query)
 
     res.status(httpStatus.OK).json(result)
   }
 
-  export const suggestion = async (
+  public suggestion = async (
     req: Request<never, never, never, Entity.RequestQuerySuggestion>,
-    res: Response,
-    next: NextFunction
+    res: Response
   ) => {
-    const result: Entity.ResponseSuggestion = await Service.suggestion(req.query)
+    const result: Entity.ResponseSuggestion = await this.districtService.suggestion(req.query)
 
     res.status(httpStatus.OK).json(result)
   }

--- a/src/modules/districts/district_http.ts
+++ b/src/modules/districts/district_http.ts
@@ -1,10 +1,12 @@
 import { Router } from 'express'
 import cache from '../../config/cache'
-import { District as Handler } from './district_handler'
+import { DistrictHandler } from './district_handler'
+
+const districtHandler = new DistrictHandler()
 
 const router = Router()
 
-router.get('/v1/districts/with-location', Handler.withLocation)
-router.get('/v1/districts/suggestion', cache(), Handler.suggestion)
+router.get('/v1/districts/with-location', districtHandler.withLocation)
+router.get('/v1/districts/suggestion', cache(), districtHandler.suggestion)
 
 export default router

--- a/src/modules/districts/district_repository.ts
+++ b/src/modules/districts/district_repository.ts
@@ -1,20 +1,21 @@
+import database from '../../config/database'
 import { convertToBoolean } from '../../helpers/constant'
 import { getPolygon } from '../../helpers/polygon'
 import { District as Entity } from './district_entity'
 
-export namespace District {
-  const { Districts } = Entity
+export class DistrictRepository {
+  private Districts = () => database<Entity.Struct>('districts')
 
-  const getWherePolygon = (requestQuery: Entity.RequestQueryWithLocation) => {
+  private getWherePolygon = (request: Entity.RequestQueryWithLocation) => {
     const wherePolygon = `ST_CONTAINS(ST_GEOMFROMTEXT('${getPolygon(
-      requestQuery.bounds
+      request.bounds
     )}'), districts.location)`
 
     return wherePolygon
   }
 
-  export const withLocation = (requestQuery: Entity.RequestQueryWithLocation) => {
-    const query = Districts()
+  public withLocation = (request: Entity.RequestQueryWithLocation) => {
+    const query = this.Districts()
       .select(
         'districts.id',
         'districts.name',
@@ -26,23 +27,23 @@ export namespace District {
       .where('districts.is_active', true)
       .orderBy('districts.name', 'asc')
 
-    query.whereRaw(getWherePolygon(requestQuery))
+    query.whereRaw(this.getWherePolygon(request))
 
     return query
   }
 
-  export const suggestion = (requestQuery: Entity.RequestQuerySuggestion) => {
-    const query = Districts().select('id', 'name').orderBy('name', 'asc')
+  public suggestion = (request: Entity.RequestQuerySuggestion) => {
+    const query = this.Districts().select('id', 'name').orderBy('name', 'asc')
 
-    if (requestQuery.name) query.where('name', 'LIKE', `%${requestQuery.name}%`)
-    if (requestQuery.is_active) query.where('is_active', convertToBoolean(requestQuery.is_active))
-    if (requestQuery.city_id) query.where('city_id', requestQuery.city_id)
+    if (request.name) query.where('name', 'LIKE', `%${request.name}%`)
+    if (request.is_active) query.where('is_active', convertToBoolean(request.is_active))
+    if (request.city_id) query.where('city_id', request.city_id)
 
     return query
   }
 
-  export const getTotalWithLocation = () => {
-    const query = Districts().count('id', { as: 'total' }).where('is_active', true).first()
+  public getTotalWithLocation = () => {
+    const query = this.Districts().count('id', { as: 'total' }).where('is_active', true).first()
 
     return query
   }

--- a/src/modules/districts/district_rules.ts
+++ b/src/modules/districts/district_rules.ts
@@ -1,1 +1,1 @@
-export namespace District {}
+export namespace DistrictRules {}

--- a/src/modules/districts/district_service.ts
+++ b/src/modules/districts/district_service.ts
@@ -1,9 +1,15 @@
 import { isRequestBounds } from '../../helpers/polygon'
 import { District as Entity } from './district_entity'
-import { District as Repository } from './district_repository'
+import { DistrictRepository } from './district_repository'
 
-export namespace District {
-  const responseWithLocation = (items: any[]): Entity.WithLocation[] => {
+export class DistrictService {
+  private districtRepository: DistrictRepository
+
+  constructor(districtRepository: DistrictRepository = new DistrictRepository()) {
+    this.districtRepository = districtRepository
+  }
+
+  private responseWithLocation = (items: any[]): Entity.WithLocation[] => {
     const data: Entity.WithLocation[] = []
     for (const item of items) {
       data.push({
@@ -23,16 +29,16 @@ export namespace District {
     return data
   }
 
-  export const withLocation = async (
-    requestQuery: Entity.RequestQueryWithLocation
+  public withLocation = async (
+    request: Entity.RequestQueryWithLocation
   ): Promise<Entity.ResponseWithLocation> => {
-    const items: any = isRequestBounds(requestQuery.bounds)
-      ? await Repository.withLocation(requestQuery)
+    const items: any = isRequestBounds(request.bounds)
+      ? await this.districtRepository.withLocation(request)
       : []
-    const total: any = await Repository.getTotalWithLocation()
+    const total: any = await this.districtRepository.getTotalWithLocation()
 
     const result: Entity.ResponseWithLocation = {
-      data: responseWithLocation(items),
+      data: this.responseWithLocation(items),
       meta: {
         total: total.total,
       },
@@ -41,10 +47,10 @@ export namespace District {
     return result
   }
 
-  export const suggestion = async (
-    requestQuery: Entity.RequestQuerySuggestion
+  public suggestion = async (
+    request: Entity.RequestQuerySuggestion
   ): Promise<Entity.ResponseSuggestion> => {
-    const items: any = await Repository.suggestion(requestQuery)
+    const items: any = await this.districtRepository.suggestion(request)
 
     const result: Entity.ResponseSuggestion = {
       data: items,

--- a/src/modules/pages/page_access.ts
+++ b/src/modules/pages/page_access.ts
@@ -2,7 +2,7 @@ import config from '../../config'
 import { accessControl, AccessControlStruct } from '../../helpers/rbac'
 import grantAccess from '../../middleware/grantAccess'
 
-export namespace Page {
+export namespace PageAccess {
   const flatList: AccessControlStruct[] = [
     {
       role: config.get('role.0'),

--- a/src/modules/pages/page_entity.ts
+++ b/src/modules/pages/page_entity.ts
@@ -1,8 +1,7 @@
-import database from '../../config/database'
 import { metaPaginate } from '../../helpers/paginate'
 import { Query } from '../../helpers/types'
 
-export namespace Page {
+export namespace PageEntity {
   export interface Struct {
     id?: number
     created_by?: string
@@ -21,9 +20,6 @@ export namespace Page {
     source: string
     created_at?: Date
   }
-
-  export const Pages = () => database<Struct>('pages')
-  export const Files = () => database<StructFile>('files')
 
   export interface Response {
     id: string

--- a/src/modules/pages/page_handler.ts
+++ b/src/modules/pages/page_handler.ts
@@ -1,50 +1,58 @@
 import { Request, Response, NextFunction } from 'express'
 import httpStatus from 'http-status'
-import { Page as Entity } from './page_entity'
-import { Page as Service } from './page_service'
+import { getUser, User } from '../../helpers/rbac'
+import { PageEntity } from './page_entity'
+import { PageService } from './page_service'
 
-export namespace Page {
-  export const findAll = async (
-    req: Request<never, never, never, Entity.RequestQuery>,
+export class PageHandler {
+  private pageService: PageService
+
+  constructor(pageService: PageService = new PageService()) {
+    this.pageService = pageService
+  }
+
+  public findAll = async (
+    req: Request<never, never, never, PageEntity.RequestQuery>,
     res: Response,
     next: NextFunction
   ) => {
-    const result: Entity.ResponseFindAll = await Service.findAll(req.query)
+    const result: PageEntity.ResponseFindAll = await this.pageService.findAll(req.query)
 
     res.status(httpStatus.OK).json(result)
   }
 
-  export const findById = async (req: Request, res: Response, next: NextFunction) => {
+  public findById = async (req: Request, res: Response, next: NextFunction) => {
     try {
       const { id } = req.params
-      const result: Entity.ResponseFindById = await Service.findById(id)
+      const result: PageEntity.ResponseFindById = await this.pageService.findById(id)
       res.status(httpStatus.OK).json(result)
     } catch (error) {
       next(error)
     }
   }
 
-  export const store = async (req: Request, res: Response, next: NextFunction) => {
-    const { body, user } = req
-    await Service.store(body, user)
+  public store = async (req: Request, res: Response) => {
+    const user: User = getUser(req)
+    const { body } = req
+    await this.pageService.store(body, user)
     res.status(httpStatus.CREATED).json({ message: 'CREATED' })
   }
 
-  export const destroy = async (req: Request, res: Response, next: NextFunction) => {
+  public destroy = async (req: Request, res: Response, next: NextFunction) => {
     try {
       const { id } = req.params
-      await Service.destroy(id)
+      await this.pageService.destroy(id)
       res.status(httpStatus.OK).json({ message: 'DELETED' })
     } catch (error) {
       next(error)
     }
   }
 
-  export const update = async (req: Request, res: Response, next: NextFunction) => {
+  public update = async (req: Request, res: Response, next: NextFunction) => {
     try {
       const { id } = req.params
       const { body } = req
-      await Service.update(body, id)
+      await this.pageService.update(body, id)
       res.status(httpStatus.OK).json({ message: 'UPDATED' })
     } catch (error) {
       next(error)

--- a/src/modules/pages/page_http.ts
+++ b/src/modules/pages/page_http.ts
@@ -2,30 +2,32 @@ import { Router } from 'express'
 import cache from '../../config/cache'
 import { validate, validateWithDB } from '../../helpers/validator'
 import { verifyAccessToken } from '../../middleware/jwt'
-import { Page as Access } from './page_access'
-import { Page as Handler } from './page_handler'
-import { Page as Rules } from './page_rules'
+import { PageAccess } from './page_access'
+import { PageHandler } from './page_handler'
+import { PageRules } from './page_rules'
+
+const pageHandler = new PageHandler()
 
 const router = Router()
 
-router.get('/v1/pages', cache(), validate(Rules.findAll, 'query'), Handler.findAll)
-router.get('/v1/pages/:id', verifyAccessToken, Access.findById(), Handler.findById)
+router.get('/v1/pages', cache(), validate(PageRules.findAll, 'query'), pageHandler.findAll)
+router.get('/v1/pages/:id', verifyAccessToken, PageAccess.findById(), pageHandler.findById)
 router.post(
   '/v1/pages',
   verifyAccessToken,
-  Access.store(),
-  validate(Rules.store),
-  validateWithDB(Rules.storeWithDB),
-  Handler.store
+  PageAccess.store(),
+  validate(PageRules.store),
+  validateWithDB(PageRules.storeWithDB),
+  pageHandler.store
 )
-router.delete('/v1/pages/:id', verifyAccessToken, Access.destroy(), Handler.destroy)
+router.delete('/v1/pages/:id', verifyAccessToken, PageAccess.destroy(), pageHandler.destroy)
 router.put(
   '/v1/pages/:id',
   verifyAccessToken,
-  Access.update(),
-  validate(Rules.update),
-  validateWithDB(Rules.updateWithDB),
-  Handler.update
+  PageAccess.update(),
+  validate(PageRules.update),
+  validateWithDB(PageRules.updateWithDB),
+  pageHandler.update
 )
 
 export default router

--- a/src/modules/pages/page_log.ts
+++ b/src/modules/pages/page_log.ts
@@ -1,1 +1,1 @@
-export namespace Page {}
+export namespace PageLog {}

--- a/src/modules/pages/page_repository.ts
+++ b/src/modules/pages/page_repository.ts
@@ -1,12 +1,15 @@
+import database from '../../config/database'
 import { convertToBoolean } from '../../helpers/constant'
 import { pagination } from '../../helpers/paginate'
-import { Page as Entity } from './page_entity'
+import { PageEntity } from './page_entity'
 
-export namespace Page {
-  const { Pages, Files } = Entity
+export class PageRepository {
+  private Pages = () => database<PageEntity.Struct>('pages')
 
-  const Query = () =>
-    Pages()
+  private Files = () => database<PageEntity.StructFile>('files')
+
+  private Query = () =>
+    this.Pages()
       .select(
         'pages.id',
         'title',
@@ -21,50 +24,50 @@ export namespace Page {
       )
       .leftJoin('files', 'files.source', '=', 'pages.image')
 
-  export const findAll = (requestQuery: Entity.RequestQuery) => {
-    const orderBy: string = requestQuery.order_by || 'created_at'
-    const sortBy: string = requestQuery.sort_by || 'desc'
+  public findAll = (request: PageEntity.RequestQuery) => {
+    const orderBy: string = request.order_by || 'created_at'
+    const sortBy: string = request.sort_by || 'desc'
 
-    const query = Query().orderBy(orderBy, sortBy)
+    const query = this.Query().orderBy(orderBy, sortBy)
 
-    if (requestQuery.q) query.where('title', 'like', `%${requestQuery.q}%`)
+    if (request.q) query.where('title', 'like', `%${request.q}%`)
 
-    if (requestQuery.is_active) query.where('is_active', convertToBoolean(requestQuery.is_active))
+    if (request.is_active) query.where('is_active', convertToBoolean(request.is_active))
 
-    return query.paginate(pagination(requestQuery))
+    return query.paginate(pagination(request))
   }
 
-  export const findById = (id: string) => Query().where('pages.id', Number(id)).first()
+  public findById = (id: string) => this.Query().where('pages.id', Number(id)).first()
 
-  export const store = (requestBody: Entity.Struct) =>
-    Pages().insert({
-      ...requestBody,
+  public store = (request: PageEntity.Struct) =>
+    this.Pages().insert({
+      ...request,
       created_at: new Date(),
     })
 
-  export const destroy = (id: number) => Pages().where('id', id).delete()
+  public destroy = (id: number) => this.Pages().where('id', id).delete()
 
-  export const update = (requestBody: Entity.Struct, id: number) =>
-    Pages()
+  public update = (request: PageEntity.Struct, id: number) =>
+    this.Pages()
       .where('id', id)
       .update({
-        ...requestBody,
+        ...request,
         updated_at: new Date(),
       })
 
-  export const createFile = (requestBody: Entity.StructFile) =>
-    Files()
+  public createFile = (request: PageEntity.StructFile) =>
+    this.Files()
       .insert({
-        ...requestBody,
+        ...request,
         created_at: new Date(),
       })
       .onConflict('source')
       .merge(['name', 'created_at'])
 
-  export const updateFile = (requestBody: Entity.StructFile, id: number) =>
-    Files()
+  public updateFile = (request: PageEntity.StructFile, id: number) =>
+    this.Files()
       .where('id', id)
       .update({
-        ...requestBody,
+        ...request,
       })
 }

--- a/src/modules/pages/page_rules.ts
+++ b/src/modules/pages/page_rules.ts
@@ -2,7 +2,7 @@ import Joi from 'joi'
 import { regexAlphanumeric, regexExtFile } from '../../helpers/regex'
 import { ValidationWithDB } from '../../helpers/validator'
 
-export namespace Page {
+export namespace PageRules {
   const orderByValid = ['title', 'is_active', 'updated_at', 'order', 'created_at']
   const emptyAllow = ['', null]
 

--- a/src/modules/pages/page_test.ts
+++ b/src/modules/pages/page_test.ts
@@ -3,7 +3,7 @@ import faker from 'faker'
 import httpStatus from 'http-status'
 import { v4 as uuidv4 } from 'uuid'
 import app from '../../server'
-import { Page as Entity } from './page_entity'
+import { PageEntity } from './page_entity'
 import { createAccessToken } from '../../middleware/jwt'
 
 const expectMeta = expect.objectContaining({
@@ -48,7 +48,7 @@ const accessToken = createAccessToken({
 
 const title = faker.lorem.slug(2)
 
-const data = (): Entity.RequestBody => ({
+const data = (): PageEntity.RequestBody => ({
   title,
   link: faker.internet.url(),
   is_active: true,
@@ -57,7 +57,7 @@ const data = (): Entity.RequestBody => ({
   image_original_name: faker.image.avatar(),
 })
 
-const dataRandomTitle = (): Entity.RequestBody => ({ ...data(), title: faker.lorem.slug(2) })
+const dataRandomTitle = (): PageEntity.RequestBody => ({ ...data(), title: faker.lorem.slug(2) })
 
 let pagesId: number
 


### PR DESCRIPTION
# Overview

- refactor: modify method to class (Pages & Districts)
- consistency of class name and namespace

## why change to class? 
- to make it easier to test unit tests
- more reusable

## Evidence
- title: refactor: modify method to class (Pages & Districts)
- project: Desa Digital
- participants: @ayocodingit @indraprasetya154 @sandisunandar99  @rachadiannovansyah 