### PR TITLE
Add response field status partner (users)

### DIFF
--- a/src/modules/partners/partner_service.ts
+++ b/src/modules/partners/partner_service.ts
@@ -24,7 +24,7 @@ export class PartnerService {
       data: this.partnerResponse.findAll(items.data),
       meta: {
         ...metaPagination(items.pagination),
-        last_update: lastUpdate?.created_at || null,
+        last_update: lastUpdate.created_at,
       },
     }
 

--- a/src/modules/users/user_repository.ts
+++ b/src/modules/users/user_repository.ts
@@ -53,7 +53,8 @@ export class UserRepository {
         'users.status_partner',
         'files.name as file_name',
         'files.id as file_id',
-        'partners.name as partner_name'
+        'partners.name as partner_name',
+        'partners.id as partner_id'
       )
       .leftJoin('files', 'files.source', '=', 'users.avatar')
       .leftJoin('partners', 'partners.id', '=', 'users.partner_id')

--- a/src/modules/users/user_repository.ts
+++ b/src/modules/users/user_repository.ts
@@ -79,7 +79,6 @@ export class UserRepository {
       id: uuidv4(),
       verified_at: new Date(),
       created_at: new Date(),
-      updated_at: new Date(),
     })
 
   public createFile = (request: UserEntity.File) =>

--- a/src/modules/users/user_repository.ts
+++ b/src/modules/users/user_repository.ts
@@ -53,8 +53,7 @@ export class UserRepository {
         'users.status_partner',
         'files.name as file_name',
         'files.id as file_id',
-        'partners.name as partner_name',
-        'partners.id as partner_id'
+        'partners.name as partner_name'
       )
       .leftJoin('files', 'files.source', '=', 'users.avatar')
       .leftJoin('partners', 'partners.id', '=', 'users.partner_id')

--- a/src/modules/users/user_response.ts
+++ b/src/modules/users/user_response.ts
@@ -20,6 +20,7 @@ export class UserResponse {
     is_active: convertToBoolean(item.is_active),
     created_at: item.created_at,
     updated_at: item.updated_at,
+    status_partner: item.status_partner,
     last_login_at: item.last_login_at,
   })
 

--- a/src/modules/users/user_service.ts
+++ b/src/modules/users/user_service.ts
@@ -109,7 +109,13 @@ export class UserService {
       item.file_id
     )
 
-    return this.userRepository.update(this.getRequestBody(request), id)
+    const payload = this.getRequestBody(request) as UserEntity.User
+
+    if (request.roles === config.get('role.1')) {
+      payload.partner_id = await this.getPartnerId(request.company)
+    }
+
+    return this.userRepository.update(payload, id)
   }
 
   public updateStatus = async (request: UserEntity.RequestBodyUpdateStatus, id: string) => {

--- a/src/modules/users/user_service.ts
+++ b/src/modules/users/user_service.ts
@@ -111,6 +111,7 @@ export class UserService {
 
     const payload = this.getRequestBody(request) as UserEntity.User
 
+    // check if roles is partner and partner is changes
     if (request.roles === config.get('role.1') && item.partner_name !== request.company) {
       payload.partner_id = await this.getPartnerId(request.company)
     }

--- a/src/modules/users/user_service.ts
+++ b/src/modules/users/user_service.ts
@@ -111,7 +111,7 @@ export class UserService {
 
     const payload = this.getRequestBody(request) as UserEntity.User
 
-    // check if roles is partner and partner is changes
+    // check if roles is partner and partners are changing
     if (request.roles === config.get('role.1') && item.partner_name !== request.company) {
       payload.partner_id = await this.getPartnerId(request.company)
     }

--- a/src/modules/users/user_service.ts
+++ b/src/modules/users/user_service.ts
@@ -111,7 +111,7 @@ export class UserService {
 
     const payload = this.getRequestBody(request) as UserEntity.User
 
-    if (request.roles === config.get('role.1')) {
+    if (request.roles === config.get('role.1') && item.partner_name !== request.company) {
       payload.partner_id = await this.getPartnerId(request.company)
     }
 

--- a/src/modules/users/user_test.ts
+++ b/src/modules/users/user_test.ts
@@ -216,6 +216,19 @@ describe('test users', () => {
 })
 
 describe('test users', () => {
+  it('test success update as partner', async () =>
+    request(app)
+      .put(`/v1/users/${userId}`)
+      .send({
+        ...data(),
+        roles: config.get('role.1'),
+        company: faker.name.firstName(),
+      })
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(httpStatus.OK))
+})
+
+describe('test users', () => {
   it('test failed destroy not found', async () =>
     request(app)
       .delete('/v1/users/9999')

--- a/src/modules/users/user_test.ts
+++ b/src/modules/users/user_test.ts
@@ -74,6 +74,7 @@ const expectResponse = expect.objectContaining({
   is_active: expect.any(Boolean),
   created_at: expect.toBeOneOf([null, expect.any(String)]),
   updated_at: expect.toBeOneOf([null, expect.any(String)]),
+  status_partner: expect.toBeOneOf([null, expect.any(String)]),
   last_login_at: expect.toBeOneOf([null, expect.any(String)]),
 })
 


### PR DESCRIPTION
## Overview
- add response field status partner (users)
- enhancement: add condition for roles partner on update

## Link 
- continue from MR #195 

## Evidence
- title: add response field status partner (users)
- project: Desa Digital
- participants: @ayocodingit @rindibudiaramdhan 