### PR TITLE
refactor: rename status partner to status (users)

### DIFF
--- a/src/database/migrations/20220907064635_rename_field_status_partner_to_status_on_table_users.ts
+++ b/src/database/migrations/20220907064635_rename_field_status_partner_to_status_on_table_users.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex'
+
+const tableName = 'users'
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.alterTable(tableName, (table) => {
+    table.renameColumn('status_partner', 'status')
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.alterTable(tableName, (table) => {
+    table.renameColumn('status', 'status_partner')
+  })
+}

--- a/src/helpers/constant.ts
+++ b/src/helpers/constant.ts
@@ -15,7 +15,7 @@ export const IsJsonString = (str: string) => {
   return isJsonString
 }
 
-export enum StatusUser {
+export enum UserStatus {
   WAITING = 'Menunggu Verifikasi',
   VERIFIED = 'Terverifikasi',
   REJECTED = 'Ditolak',

--- a/src/helpers/constant.ts
+++ b/src/helpers/constant.ts
@@ -15,7 +15,7 @@ export const IsJsonString = (str: string) => {
   return isJsonString
 }
 
-export enum StatusPartner {
+export enum StatusUser {
   WAITING = 'Menunggu Verifikasi',
   VERIFIED = 'Terverifikasi',
   REJECTED = 'Ditolak',

--- a/src/helpers/templateEmail.ts
+++ b/src/helpers/templateEmail.ts
@@ -1,5 +1,0 @@
-export const templateEmailVerifyAccepted = () => ``
-
-export const templateEmailInvitationPartner = () => ``
-
-export const templateEmailVerifyRejected = (notes: string) => ``

--- a/src/modules/auth/auth_entity.ts
+++ b/src/modules/auth/auth_entity.ts
@@ -13,7 +13,7 @@ export namespace AuthEntity {
     is_admin?: boolean
     is_active?: boolean
     last_login_at?: Date
-    status_partner?: string
+    status?: string
     notes?: string
   }
 
@@ -44,7 +44,7 @@ export namespace AuthEntity {
     is_admin?: boolean
     google_id?: string
     verified_at?: Date
-    status_partner?: string
+    status?: string
   }
 
   export interface PartnerCreate {
@@ -106,6 +106,6 @@ export namespace AuthEntity {
 
   export interface UpdateStatus {
     last_login_at?: Date
-    status_partner?: string
+    status?: string
   }
 }

--- a/src/modules/auth/auth_repository.ts
+++ b/src/modules/auth/auth_repository.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid'
 import database from '../../config/database'
-import { StatusPartner } from '../../helpers/constant'
+import { StatusUser } from '../../helpers/constant'
 import { AuthEntity } from './auth_entity'
 
 export class AuthRepository {
@@ -86,8 +86,8 @@ export class AuthRepository {
     const payload = <AuthEntity.UpdateStatus>{}
 
     payload.last_login_at = new Date()
-    if (user.status_partner === StatusPartner.VERIFIED) {
-      payload.status_partner = StatusPartner.ACTIVE
+    if (user.status === StatusUser.VERIFIED) {
+      payload.status = StatusUser.ACTIVE
     }
 
     return this.Users().where('id', user.id).update(payload)

--- a/src/modules/auth/auth_repository.ts
+++ b/src/modules/auth/auth_repository.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid'
 import database from '../../config/database'
-import { StatusUser } from '../../helpers/constant'
+import { UserStatus } from '../../helpers/constant'
 import { AuthEntity } from './auth_entity'
 
 export class AuthRepository {
@@ -86,8 +86,8 @@ export class AuthRepository {
     const payload = <AuthEntity.UpdateStatus>{}
 
     payload.last_login_at = new Date()
-    if (user.status === StatusUser.VERIFIED) {
-      payload.status = StatusUser.ACTIVE
+    if (user.status === UserStatus.VERIFIED) {
+      payload.status = UserStatus.ACTIVE
     }
 
     return this.Users().where('id', user.id).update(payload)

--- a/src/modules/auth/auth_service.ts
+++ b/src/modules/auth/auth_service.ts
@@ -10,7 +10,7 @@ import * as jwt from '../../middleware/jwt'
 import { sendMail as SendMail } from '../../helpers/mail'
 import config from '../../config'
 import { getRole, User } from '../../helpers/rbac'
-import { convertToBoolean, StatusPartner } from '../../helpers/constant'
+import { convertToBoolean, StatusUser } from '../../helpers/constant'
 import { passwordHash } from '../../helpers/passwordHash'
 import { getUrl } from '../../helpers/cloudStorage'
 
@@ -36,7 +36,7 @@ export class AuthService {
     }
 
     user.partner_id = await this.authRepository.getPartnerId(request)
-    user.status_partner = user.partner_id ? StatusPartner.WAITING : null
+    user.status = user.partner_id ? StatusUser.WAITING : null
 
     return this.authRepository.signUp(user)
   }

--- a/src/modules/auth/auth_service.ts
+++ b/src/modules/auth/auth_service.ts
@@ -10,7 +10,7 @@ import * as jwt from '../../middleware/jwt'
 import { sendMail as SendMail } from '../../helpers/mail'
 import config from '../../config'
 import { getRole, User } from '../../helpers/rbac'
-import { convertToBoolean, StatusUser } from '../../helpers/constant'
+import { convertToBoolean, UserStatus } from '../../helpers/constant'
 import { passwordHash } from '../../helpers/passwordHash'
 import { getUrl } from '../../helpers/cloudStorage'
 
@@ -36,7 +36,7 @@ export class AuthService {
     }
 
     user.partner_id = await this.authRepository.getPartnerId(request)
-    user.status = user.partner_id ? StatusUser.WAITING : null
+    user.status = user.partner_id ? UserStatus.WAITING : null
 
     return this.authRepository.signUp(user)
   }

--- a/src/modules/users/user_entity.ts
+++ b/src/modules/users/user_entity.ts
@@ -16,7 +16,7 @@ export namespace UserEntity {
     updated_at?: Date
     verified_at?: Date
     last_login_at?: Date
-    status_partner?: string
+    status?: string
     notes?: string
   }
 
@@ -50,7 +50,7 @@ export namespace UserEntity {
     is_active: boolean
     created_at?: Date
     updated_at?: Date
-    status_partner?: string
+    status?: string
     last_login_at?: Date
   }
 
@@ -77,12 +77,12 @@ export namespace UserEntity {
 
   export interface RequestBodyUpdateStatus {
     is_active: boolean
-    status_partner?: string
+    status?: string
   }
 
   export interface Verify {
     notes?: string
-    status_partner?: string
+    status?: string
     is_active?: boolean
   }
 

--- a/src/modules/users/user_repository.ts
+++ b/src/modules/users/user_repository.ts
@@ -50,7 +50,7 @@ export class UserRepository {
         'users.created_at',
         'users.updated_at',
         'users.last_login_at',
-        'users.status_partner',
+        'users.status',
         'files.name as file_name',
         'files.id as file_id',
         'partners.name as partner_name'

--- a/src/modules/users/user_response.ts
+++ b/src/modules/users/user_response.ts
@@ -20,7 +20,7 @@ export class UserResponse {
     is_active: convertToBoolean(item.is_active),
     created_at: item.created_at,
     updated_at: item.updated_at,
-    status_partner: item.status_partner,
+    status: item.status,
     last_login_at: item.last_login_at,
   })
 

--- a/src/modules/users/user_rules.ts
+++ b/src/modules/users/user_rules.ts
@@ -10,7 +10,7 @@ export namespace UserRules {
     'users.email',
     'users.updated_at',
     'users.created_at',
-    'users.status_partner',
+    'users.status',
     'partners.name',
   ]
   const roles = [config.get('role.0'), config.get('role.1')]

--- a/src/modules/users/user_service.ts
+++ b/src/modules/users/user_service.ts
@@ -1,7 +1,7 @@
 import httpStatus from 'http-status'
 import config from '../../config'
 import { HttpError } from '../../handler/exception'
-import { convertToBoolean, StatusUser } from '../../helpers/constant'
+import { convertToBoolean, UserStatus } from '../../helpers/constant'
 import { Payload, sendMail as SendMail } from '../../helpers/mail'
 import { metaPagination } from '../../helpers/paginate'
 import { passwordHash } from '../../helpers/passwordHash'
@@ -80,7 +80,7 @@ export class UserService {
 
   private setStorePartner = async (payload: UserEntity.User, request: UserEntity.RequestBody) => {
     payload.partner_id = await this.userRepository.storePartner(request.company)
-    payload.status = StatusUser.VERIFIED
+    payload.status = UserStatus.VERIFIED
 
     return payload
   }
@@ -153,9 +153,9 @@ export class UserService {
       is_active,
     }
 
-    const isStatusActiveInactive = [StatusUser.ACTIVE, StatusUser.INACTIVE].includes(item.status)
+    const isStatusActiveInactive = [UserStatus.ACTIVE, UserStatus.INACTIVE].includes(item.status)
 
-    const status = is_active ? StatusUser.ACTIVE : StatusUser.INACTIVE
+    const status = is_active ? UserStatus.ACTIVE : UserStatus.INACTIVE
 
     if (isStatusActiveInactive) payload.status = status
 
@@ -167,19 +167,19 @@ export class UserService {
     if (!item)
       throw new HttpError(httpStatus.NOT_FOUND, lang.__('error.exists', { entity: 'user', id }))
 
-    if (item.status !== StatusUser.WAITING)
+    if (item.status !== UserStatus.WAITING)
       throw new HttpError(httpStatus.BAD_REQUEST, lang.__('error.users.partner.verified'))
 
     const is_verify = convertToBoolean(request.is_verify)
     const payload = <UserEntity.Verify>{
       is_active: true,
-      status: StatusUser.ACTIVE,
+      status: UserStatus.ACTIVE,
     }
 
     if (!is_verify) {
       payload.notes = request.notes
       payload.is_active = false
-      payload.status = StatusUser.REJECTED
+      payload.status = UserStatus.REJECTED
     }
 
     this.sendEmailVerify(item.email, is_verify, request.notes)

--- a/src/modules/users/user_service.ts
+++ b/src/modules/users/user_service.ts
@@ -1,7 +1,7 @@
 import httpStatus from 'http-status'
 import config from '../../config'
 import { HttpError } from '../../handler/exception'
-import { convertToBoolean, StatusPartner } from '../../helpers/constant'
+import { convertToBoolean, StatusUser } from '../../helpers/constant'
 import { Payload, sendMail as SendMail } from '../../helpers/mail'
 import { metaPagination } from '../../helpers/paginate'
 import { passwordHash } from '../../helpers/passwordHash'
@@ -80,7 +80,7 @@ export class UserService {
 
   private setStorePartner = async (payload: UserEntity.User, request: UserEntity.RequestBody) => {
     payload.partner_id = await this.userRepository.storePartner(request.company)
-    payload.status_partner = StatusPartner.VERIFIED
+    payload.status = StatusUser.VERIFIED
 
     return payload
   }
@@ -153,13 +153,11 @@ export class UserService {
       is_active,
     }
 
-    const isStatusActiveInactive = [StatusPartner.ACTIVE, StatusPartner.INACTIVE].includes(
-      item.status_partner
-    )
+    const isStatusActiveInactive = [StatusUser.ACTIVE, StatusUser.INACTIVE].includes(item.status)
 
-    const status_partner = is_active ? StatusPartner.ACTIVE : StatusPartner.INACTIVE
+    const status = is_active ? StatusUser.ACTIVE : StatusUser.INACTIVE
 
-    if (isStatusActiveInactive) payload.status_partner = status_partner
+    if (isStatusActiveInactive) payload.status = status
 
     return this.userRepository.updateStatus(payload, id)
   }
@@ -169,19 +167,19 @@ export class UserService {
     if (!item)
       throw new HttpError(httpStatus.NOT_FOUND, lang.__('error.exists', { entity: 'user', id }))
 
-    if (item.status_partner !== StatusPartner.WAITING)
+    if (item.status !== StatusUser.WAITING)
       throw new HttpError(httpStatus.BAD_REQUEST, lang.__('error.users.partner.verified'))
 
     const is_verify = convertToBoolean(request.is_verify)
     const payload = <UserEntity.Verify>{
       is_active: true,
-      status_partner: StatusPartner.ACTIVE,
+      status: StatusUser.ACTIVE,
     }
 
     if (!is_verify) {
       payload.notes = request.notes
       payload.is_active = false
-      payload.status_partner = StatusPartner.REJECTED
+      payload.status = StatusUser.REJECTED
     }
 
     this.sendEmailVerify(item.email, is_verify, request.notes)

--- a/src/modules/users/user_test.ts
+++ b/src/modules/users/user_test.ts
@@ -5,7 +5,7 @@ import request from 'supertest'
 import { v4 as uuidv4 } from 'uuid'
 import config from '../../config'
 import database from '../../config/database'
-import { StatusUser } from '../../helpers/constant'
+import { UserStatus } from '../../helpers/constant'
 import { createAccessToken } from '../../middleware/jwt'
 import app from '../../server'
 import { UserEntity } from './user_entity'
@@ -212,7 +212,7 @@ describe('test users', () => {
 describe('test users', () => {
   it('update users partner status partner set inactive', async () => {
     await database('users').whereNotNull('partner_id').update({
-      status: StatusUser.INACTIVE,
+      status: UserStatus.INACTIVE,
     })
   })
 })
@@ -283,7 +283,7 @@ describe('test users', () => {
 describe('test users', () => {
   it('update users partner status partner set waiting', async () => {
     await database('users').where('id', userIdPartner).update({
-      status: StatusUser.WAITING,
+      status: UserStatus.WAITING,
     })
   })
 })
@@ -300,7 +300,7 @@ describe('test users', () => {
 describe('test users', () => {
   it('update users partner status partner set waiting', async () => {
     await database('users').where('id', userIdPartner).update({
-      status: StatusUser.WAITING,
+      status: UserStatus.WAITING,
     })
   })
 })

--- a/src/modules/users/user_test.ts
+++ b/src/modules/users/user_test.ts
@@ -5,7 +5,7 @@ import request from 'supertest'
 import { v4 as uuidv4 } from 'uuid'
 import config from '../../config'
 import database from '../../config/database'
-import { StatusPartner } from '../../helpers/constant'
+import { StatusUser } from '../../helpers/constant'
 import { createAccessToken } from '../../middleware/jwt'
 import app from '../../server'
 import { UserEntity } from './user_entity'
@@ -84,7 +84,7 @@ const expectResponse = expect.objectContaining({
   is_active: expect.any(Boolean),
   created_at: expect.toBeOneOf([null, expect.any(String)]),
   updated_at: expect.toBeOneOf([null, expect.any(String)]),
-  status_partner: expect.toBeOneOf([null, expect.any(String)]),
+  status: expect.toBeOneOf([null, expect.any(String)]),
   last_login_at: expect.toBeOneOf([null, expect.any(String)]),
 })
 
@@ -212,7 +212,7 @@ describe('test users', () => {
 describe('test users', () => {
   it('update users partner status partner set inactive', async () => {
     await database('users').whereNotNull('partner_id').update({
-      status_partner: StatusPartner.INACTIVE,
+      status: StatusUser.INACTIVE,
     })
   })
 })
@@ -283,7 +283,7 @@ describe('test users', () => {
 describe('test users', () => {
   it('update users partner status partner set waiting', async () => {
     await database('users').where('id', userIdPartner).update({
-      status_partner: StatusPartner.WAITING,
+      status: StatusUser.WAITING,
     })
   })
 })
@@ -300,7 +300,7 @@ describe('test users', () => {
 describe('test users', () => {
   it('update users partner status partner set waiting', async () => {
     await database('users').where('id', userIdPartner).update({
-      status_partner: StatusPartner.WAITING,
+      status: StatusUser.WAITING,
     })
   })
 })


### PR DESCRIPTION
# Overview
- refactor: rename status partner to status (users)
- why should it be renamed, after analyzing this status, various roles are used, so general

## Link / Related Issue
- 

## Todo
- run migrate

## Evidence
- Title: refactor: rename status partner to status (users)
- Project: Desa Digital
- Participants: @ayocodingit @imamdev93 @rachadiannovansyah 