### PR TITLE
scripts: add migrate seed make

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,8 @@
     "lint:fix": "npx prettier ./src --write && eslint --fix --ext .ts ./src",
     "migrate": "knex migrate:latest --cwd=build/src",
     "rollback": "knex migrate:rollback --cwd=build/src",
+    "migrate:make": "knex migrate:make --cwd=src $npm_config_name",
+    "seed:make": "knex seed:make --cwd=src $npm_config_name",
     "seed": "knex seed:run --cwd=build/src",
     "refresh": "npm run rollback && npm run migrate",
     "migrate:local": "npm run build && npm run migrate",


### PR DESCRIPTION
# Overview
- scripts: add migrate seed make


# how to run example
- npm run migrate:make --name=create_table_users
- npm run seed:make --name=seeder_users

## Link / Related Issue
- 

## Todo
-

## Evidence
- Title: scripts: add migrate seed make
- Project: Desa Digital
- Participants: @ayocodingit @rachadiannovansyah @fajarhikmal214 